### PR TITLE
Use `ufmt` crate for `print!` macros

### DIFF
--- a/crates/flipperzero/Cargo.toml
+++ b/crates/flipperzero/Cargo.toml
@@ -22,6 +22,7 @@ test = false
 
 [dependencies]
 flipperzero-sys = { path = "../sys", version = "0.7.2" }
+ufmt = "0.2.0"
 
 [dev-dependencies]
 flipperzero-rt = { path = "../rt", version = "0.7.2" }

--- a/crates/flipperzero/src/furi/io.rs
+++ b/crates/flipperzero/src/furi/io.rs
@@ -1,7 +1,6 @@
 //! Furi I/O API.
 
 use core::ffi::c_char;
-use core::fmt::{Write, Arguments};
 
 use flipperzero_sys as sys;
 
@@ -9,6 +8,21 @@ pub struct Stdout;
 
 impl core::fmt::Write for Stdout {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        let len = s.len();
+        unsafe {
+            if sys::furi_thread_stdout_write(s.as_ptr() as *const c_char, len) != len {
+                return Err(core::fmt::Error);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl ufmt::uWrite for Stdout {
+    type Error = core::fmt::Error;
+
+    fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
         let len = s.len();
         unsafe {
             if sys::furi_thread_stdout_write(s.as_ptr() as *const c_char, len) != len {
@@ -30,16 +44,4 @@ impl Stdout {
 
         Ok(())
     }
-}
-
-#[doc(hidden)]
-pub fn _print(args: Arguments) {
-    // Avoid generating exception machinery
-    Stdout.write_fmt(args).ok();
-}
-
-#[doc(hidden)]
-pub fn _write_str(s: &str) {
-    // Adoid generating exception machinery
-    Stdout.write_str(s).ok();
 }

--- a/crates/flipperzero/src/lib.rs
+++ b/crates/flipperzero/src/lib.rs
@@ -10,3 +10,9 @@ pub mod dolphin;
 pub mod furi;
 pub mod gui;
 pub mod macros;
+
+#[doc(hidden)]
+pub mod __internal {
+    // Re-export for use in macros
+    pub use ufmt;
+}

--- a/crates/flipperzero/src/macros.rs
+++ b/crates/flipperzero/src/macros.rs
@@ -2,22 +2,18 @@
 
 #[macro_export]
 macro_rules! print {
-    ($pat:expr, $($args:tt)*) => {{
-        $crate::furi::io::_print(core::format_args!($pat, $($args)*));
-    }};
-
-    ($msg:expr $(,)?) => {{
-        $crate::furi::io::_write_str($msg);
+    ($($args:tt)*) => {{
+        // The `uwrite!` macro expects `ufmt` in scope
+        use $crate::__internal::ufmt;
+        ufmt::uwrite!($crate::furi::io::Stdout, $($args)*).ok();
     }};
 }
 
 #[macro_export]
 macro_rules! println {
-    ($pat:expr, $($args:tt)*) => {{
-        $crate::furi::io::_print(core::format_args!(concat!($pat, "\r\n"), $($args)*));
-    }};
-
-    ($msg:expr $(,)?) => {{
-        $crate::furi::io::_write_str(concat!($msg, "\r\n"));
+    ($($args:tt)*) => {{
+        // The `uwrite!` macro expects `ufmt` in scope
+        use $crate::__internal::ufmt;
+        ufmt::uwriteln!($crate::furi::io::Stdout, $($args)*).ok();
     }};
 }

--- a/crates/sys/Cargo.toml
+++ b/crates/sys/Cargo.toml
@@ -22,3 +22,4 @@ bench = false
 test = false
 
 [dependencies]
+ufmt = "0.2.0"

--- a/crates/sys/src/furi.rs
+++ b/crates/sys/src/furi.rs
@@ -8,7 +8,7 @@ use core::time::Duration;
 /// The Furi API switches between using `enum FuriStatus`, `int32_t` and `uint32_t`.
 /// Since these all use the same bit representation, we can just "cast" the returns to this type.
 #[repr(transparent)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, ufmt::derive::uDebug, Eq, PartialEq)]
 pub struct Status(pub i32);
 
 impl Status {
@@ -73,6 +73,14 @@ impl Status {
 impl Display for Status {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:?}: {}", self, self.description())
+    }
+}
+
+impl ufmt::uDisplay for Status {
+    fn fmt<W>(&self, f: &mut ufmt::Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: ufmt::uWrite + ?Sized {
+        ufmt::uwrite!(f, "{:?}: {}", self, self.description())
     }
 }
 

--- a/examples/dialog/Cargo.lock
+++ b/examples/dialog/Cargo.lock
@@ -37,6 +37,9 @@ dependencies = [
 [[package]]
 name = "flipperzero-sys"
 version = "0.7.2"
+dependencies = [
+ "ufmt",
+]
 
 [[package]]
 name = "proc-macro2"

--- a/examples/dialog/Cargo.lock
+++ b/examples/dialog/Cargo.lock
@@ -17,6 +17,7 @@ name = "flipperzero"
 version = "0.7.2"
 dependencies = [
  "flipperzero-sys",
+ "ufmt",
 ]
 
 [[package]]
@@ -36,3 +37,65 @@ dependencies = [
 [[package]]
 name = "flipperzero-sys"
 version = "0.7.2"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "ufmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a64846ec02b57e9108d6469d98d1648782ad6bb150a95a9baac26900bbeab9d"
+dependencies = [
+ "ufmt-macros",
+ "ufmt-write",
+]
+
+[[package]]
+name = "ufmt-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d337d3be617449165cb4633c8dece429afd83f84051024079f97ad32a9663716"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ufmt-write"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e87a2ed6b42ec5e28cc3b94c09982969e9227600b2e3dcbc1db927a84c06bd69"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"

--- a/examples/gpio/Cargo.lock
+++ b/examples/gpio/Cargo.lock
@@ -7,6 +7,7 @@ name = "flipperzero"
 version = "0.7.2"
 dependencies = [
  "flipperzero-sys",
+ "ufmt",
 ]
 
 [[package]]
@@ -28,3 +29,65 @@ dependencies = [
  "flipperzero-rt",
  "flipperzero-sys",
 ]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "ufmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a64846ec02b57e9108d6469d98d1648782ad6bb150a95a9baac26900bbeab9d"
+dependencies = [
+ "ufmt-macros",
+ "ufmt-write",
+]
+
+[[package]]
+name = "ufmt-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d337d3be617449165cb4633c8dece429afd83f84051024079f97ad32a9663716"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ufmt-write"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e87a2ed6b42ec5e28cc3b94c09982969e9227600b2e3dcbc1db927a84c06bd69"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"

--- a/examples/gpio/Cargo.lock
+++ b/examples/gpio/Cargo.lock
@@ -20,6 +20,9 @@ dependencies = [
 [[package]]
 name = "flipperzero-sys"
 version = "0.7.2"
+dependencies = [
+ "ufmt",
+]
 
 [[package]]
 name = "gpio"

--- a/examples/gui/Cargo.lock
+++ b/examples/gui/Cargo.lock
@@ -20,6 +20,9 @@ dependencies = [
 [[package]]
 name = "flipperzero-sys"
 version = "0.7.2"
+dependencies = [
+ "ufmt",
+]
 
 [[package]]
 name = "gui"

--- a/examples/gui/Cargo.lock
+++ b/examples/gui/Cargo.lock
@@ -7,6 +7,7 @@ name = "flipperzero"
 version = "0.7.2"
 dependencies = [
  "flipperzero-sys",
+ "ufmt",
 ]
 
 [[package]]
@@ -28,3 +29,65 @@ dependencies = [
  "flipperzero-rt",
  "flipperzero-sys",
 ]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "ufmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a64846ec02b57e9108d6469d98d1648782ad6bb150a95a9baac26900bbeab9d"
+dependencies = [
+ "ufmt-macros",
+ "ufmt-write",
+]
+
+[[package]]
+name = "ufmt-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d337d3be617449165cb4633c8dece429afd83f84051024079f97ad32a9663716"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ufmt-write"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e87a2ed6b42ec5e28cc3b94c09982969e9227600b2e3dcbc1db927a84c06bd69"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"

--- a/examples/hello-rust/Cargo.lock
+++ b/examples/hello-rust/Cargo.lock
@@ -20,6 +20,9 @@ dependencies = [
 [[package]]
 name = "flipperzero-sys"
 version = "0.7.2"
+dependencies = [
+ "ufmt",
+]
 
 [[package]]
 name = "hello-rust"

--- a/examples/hello-rust/Cargo.lock
+++ b/examples/hello-rust/Cargo.lock
@@ -7,6 +7,7 @@ name = "flipperzero"
 version = "0.7.2"
 dependencies = [
  "flipperzero-sys",
+ "ufmt",
 ]
 
 [[package]]
@@ -28,3 +29,65 @@ dependencies = [
  "flipperzero-rt",
  "flipperzero-sys",
 ]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "ufmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a64846ec02b57e9108d6469d98d1648782ad6bb150a95a9baac26900bbeab9d"
+dependencies = [
+ "ufmt-macros",
+ "ufmt-write",
+]
+
+[[package]]
+name = "ufmt-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d337d3be617449165cb4633c8dece429afd83f84051024079f97ad32a9663716"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ufmt-write"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e87a2ed6b42ec5e28cc3b94c09982969e9227600b2e3dcbc1db927a84c06bd69"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"

--- a/examples/hello-rust/src/main.rs
+++ b/examples/hello-rust/src/main.rs
@@ -24,7 +24,7 @@ entry!(main);
 
 // Entry point
 fn main(_args: *mut u8) -> i32 {
-    println!("Hello, Rust!");
+    println!("Hello, {}!", "Rust");
 
     0
 }

--- a/examples/notification/Cargo.lock
+++ b/examples/notification/Cargo.lock
@@ -20,6 +20,9 @@ dependencies = [
 [[package]]
 name = "flipperzero-sys"
 version = "0.7.2"
+dependencies = [
+ "ufmt",
+]
 
 [[package]]
 name = "notification"

--- a/examples/notification/Cargo.lock
+++ b/examples/notification/Cargo.lock
@@ -7,6 +7,7 @@ name = "flipperzero"
 version = "0.7.2"
 dependencies = [
  "flipperzero-sys",
+ "ufmt",
 ]
 
 [[package]]
@@ -28,3 +29,65 @@ dependencies = [
  "flipperzero-rt",
  "flipperzero-sys",
 ]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "ufmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a64846ec02b57e9108d6469d98d1648782ad6bb150a95a9baac26900bbeab9d"
+dependencies = [
+ "ufmt-macros",
+ "ufmt-write",
+]
+
+[[package]]
+name = "ufmt-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d337d3be617449165cb4633c8dece429afd83f84051024079f97ad32a9663716"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ufmt-write"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e87a2ed6b42ec5e28cc3b94c09982969e9227600b2e3dcbc1db927a84c06bd69"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"


### PR DESCRIPTION
This is far more space efficent than `core::fmt`.

Removed `"\r\n"` hack, since console now handles `"\n"` correctly.

For example a `println!("Hello, {}", "Rust")` binary:
- `ufmt`: 972 B
- `core::fmt`: 4.03 KiB (325% larger)