### PR TITLE
Updates to enable publishing test crates

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "sys",
     "rt",
     "test",
+    "test/macros",
 ]
 resolver = "2"
 

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -6,6 +6,7 @@ readme.workspace = true
 license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+description = "Rust test harness for Flipper Zero"
 autobins = false
 autotests = false
 autobenches = false

--- a/crates/test/macros/Cargo.toml
+++ b/crates/test/macros/Cargo.toml
@@ -3,6 +3,7 @@ name = "flipperzero-test-macros"
 version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
+description = "Procedural macros for flipperzero-test"
 readme.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/test/macros/Cargo.toml
+++ b/crates/test/macros/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "flipperzero-test-macros"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
+readme.workspace = true
+repository.workspace = true
+license.workspace = true
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
`flipperzero-test 0.1.0` and `flipperzero-test-macros 0.1.0` have been published from d3f48ebeeb54ffac442740998bd1575c83ed819e. This should enable downstream users to write their own tests (maybe already, maybe with some future improvement PRs).