### PR TITLE
Add format! macro

### DIFF
--- a/crates/flipperzero/src/macros.rs
+++ b/crates/flipperzero/src/macros.rs
@@ -1,5 +1,17 @@
 //! Macros for Flipper Zero.
 
+/// Creates a new [`FuriString`](crate::furi::string::FuriString) by interpolating the format string.
+#[macro_export]
+macro_rules! format {
+    ($($args:tt)*) => {{
+        // The `uwrite!` macro expects `ufmt` in scope
+        use $crate::__macro_support::ufmt;
+        let mut buf = $crate::furi::string::FuriString::new();
+        ufmt::uwrite!(buf, $($args)*).ok();
+        buf
+    }}
+}
+
 #[macro_export]
 macro_rules! print {
     ($($args:tt)*) => {{


### PR DESCRIPTION
Now that `FuriString` exists, a convenience `format!` macro should also exist.