### PR TITLE
Use ptr::NonNull instead of raw pointers

### DIFF
--- a/crates/flipperzero/src/furi/mod.rs
+++ b/crates/flipperzero/src/furi/mod.rs
@@ -1,7 +1,7 @@
 //! Furi API.
 
-pub mod log;
 pub mod io;
+pub mod log;
 pub mod message_queue;
 pub mod rng;
 pub mod string;

--- a/crates/flipperzero/src/furi/string/pattern.rs
+++ b/crates/flipperzero/src/furi/string/pattern.rs
@@ -65,17 +65,17 @@ pub trait Pattern: Sized {
 impl Pattern for &FuriString {
     #[inline]
     fn is_prefix_of(self, haystack: &FuriString) -> bool {
-        unsafe { sys::furi_string_start_with(haystack.0, self.0) }
+        unsafe { sys::furi_string_start_with(haystack.0.as_ptr(), self.0.as_ptr()) }
     }
 
     #[inline]
     fn is_suffix_of(self, haystack: &FuriString) -> bool {
-        unsafe { sys::furi_string_end_with(haystack.0, self.0) }
+        unsafe { sys::furi_string_end_with(haystack.0.as_ptr(), self.0.as_ptr()) }
     }
 
     #[inline]
     fn find_in(self, haystack: &FuriString) -> Option<usize> {
-        match unsafe { sys::furi_string_search(haystack.0, self.0, 0) } {
+        match unsafe { sys::furi_string_search(haystack.0.as_ptr(), self.0.as_ptr(), 0) } {
             FURI_STRING_FAILURE => None,
             i => Some(i),
         }
@@ -100,7 +100,7 @@ impl Pattern for &FuriString {
     fn strip_prefix_of(self, haystack: &mut FuriString) -> bool {
         let is_prefix = self.is_prefix_of(haystack);
         if is_prefix {
-            unsafe { sys::furi_string_right(haystack.0, self.len()) };
+            unsafe { sys::furi_string_right(haystack.0.as_ptr(), self.len()) };
         }
         is_prefix
     }
@@ -124,17 +124,17 @@ impl Pattern for c_char {
 
     #[inline]
     fn is_prefix_of(self, haystack: &FuriString) -> bool {
-        unsafe { sys::furi_string_start_with_str(haystack.0, [self, 0].as_ptr()) }
+        unsafe { sys::furi_string_start_with_str(haystack.0.as_ptr(), [self, 0].as_ptr()) }
     }
 
     #[inline]
     fn is_suffix_of(self, haystack: &FuriString) -> bool {
-        unsafe { sys::furi_string_end_with_str(haystack.0, [self, 0].as_ptr()) }
+        unsafe { sys::furi_string_end_with_str(haystack.0.as_ptr(), [self, 0].as_ptr()) }
     }
 
     #[inline]
     fn find_in(self, haystack: &FuriString) -> Option<usize> {
-        match unsafe { sys::furi_string_search_char(haystack.0, self, 0) } {
+        match unsafe { sys::furi_string_search_char(haystack.0.as_ptr(), self, 0) } {
             FURI_STRING_FAILURE => None,
             i => Some(i),
         }
@@ -142,7 +142,7 @@ impl Pattern for c_char {
 
     #[inline]
     fn rfind_in(self, haystack: &FuriString) -> Option<usize> {
-        match unsafe { sys::furi_string_search_rchar(haystack.0, self, 0) } {
+        match unsafe { sys::furi_string_search_rchar(haystack.0.as_ptr(), self, 0) } {
             FURI_STRING_FAILURE => None,
             i => Some(i),
         }
@@ -152,7 +152,7 @@ impl Pattern for c_char {
     fn strip_prefix_of(self, haystack: &mut FuriString) -> bool {
         let is_prefix = self.is_prefix_of(haystack);
         if is_prefix {
-            unsafe { sys::furi_string_right(haystack.0, 1) };
+            unsafe { sys::furi_string_right(haystack.0.as_ptr(), 1) };
         }
         is_prefix
     }
@@ -171,17 +171,17 @@ impl Pattern for c_char {
 impl Pattern for &CStr {
     #[inline]
     fn is_prefix_of(self, haystack: &FuriString) -> bool {
-        unsafe { sys::furi_string_start_with_str(haystack.0, self.as_ptr()) }
+        unsafe { sys::furi_string_start_with_str(haystack.0.as_ptr(), self.as_ptr()) }
     }
 
     #[inline]
     fn is_suffix_of(self, haystack: &FuriString) -> bool {
-        unsafe { sys::furi_string_end_with_str(haystack.0, self.as_ptr()) }
+        unsafe { sys::furi_string_end_with_str(haystack.0.as_ptr(), self.as_ptr()) }
     }
 
     #[inline]
     fn find_in(self, haystack: &FuriString) -> Option<usize> {
-        match unsafe { sys::furi_string_search_str(haystack.0, self.as_ptr(), 0) } {
+        match unsafe { sys::furi_string_search_str(haystack.0.as_ptr(), self.as_ptr(), 0) } {
             FURI_STRING_FAILURE => None,
             i => Some(i),
         }
@@ -206,7 +206,7 @@ impl Pattern for &CStr {
     fn strip_prefix_of(self, haystack: &mut FuriString) -> bool {
         let is_prefix = self.is_prefix_of(haystack);
         if is_prefix {
-            unsafe { sys::furi_string_right(haystack.0, self.to_bytes().len()) };
+            unsafe { sys::furi_string_right(haystack.0.as_ptr(), self.to_bytes().len()) };
         }
         is_prefix
     }


### PR DESCRIPTION
This allows rust's null pointer optimization to kick in. For example, with this change the size of `Option<FuriString>` becomes 8 -> 4.
As far as I can tell, flipperzero's malloc doesn't ever return null but crashes the app instead.
See https://github.com/flipperdevices/flipperzero-firmware/blob/0.82.3/furi/core/memmgr_heap.c#L484
That's the function that `malloc` calls directly, it has the only return statement at the very end, and `furi_check` just crashes the app if the condition is false, i.e. the pointer is null.

I think I caught all the structs, I'm happy to add more if I didn't.