### PR TITLE
rt: Move thread waiter into a module

### DIFF
--- a/crates/rt/src/lib.rs
+++ b/crates/rt/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod manifest;
 pub mod panic_handler;
+mod thread;
 
 /// The C entry point.
 /// This just delegates to the user's Rust entry point.
@@ -28,77 +29,27 @@ macro_rules! entry {
         // lld seems not to automatically rename `.rel.text.main` properly.
         #[export_name = "main"]
         pub unsafe fn __main(args: *mut u8) -> i32 {
-            use core::{ffi::CStr, mem, ptr, slice};
-            use flipperzero_sys as sys;
-
             // type check the entry function
             let f: fn(*mut u8) -> i32 = $path;
 
             let ret = f(args);
 
-            // Wait for threads with the same app ID to finish. We assume there are not
-            // more than 30 threads running in the background outside this app, so we will
-            // observe at least one of any thread the app might have left running.
-            unsafe {
-                sys::furi_log_print_format(
-                    sys::FuriLogLevel_FuriLogLevelDebug,
-                    sys::c_string!("flipperzero-rt"),
-                    sys::c_string!("Waiting for FAP threads to complete..."),
-                );
-            }
-
-            const MAX_THREADS: usize = 32;
-            let cur_thread_id = unsafe { sys::furi_thread_get_current_id() };
-            let app_id = unsafe { CStr::from_ptr(sys::furi_thread_get_appid(cur_thread_id)) };
-            let mut thread_ids: [sys::FuriThreadId; MAX_THREADS] = [ptr::null_mut(); MAX_THREADS];
-
-            'outer: loop {
-                let thread_count = unsafe {
-                    sys::furi_thread_enumerate(thread_ids.as_mut_ptr(), MAX_THREADS as u32)
-                } as usize;
-
-                for &thread_id in thread_ids[..thread_count].into_iter() {
-                    let thread_app_id =
-                        unsafe { CStr::from_ptr(sys::furi_thread_get_appid(thread_id)) };
-
-                    if thread_id == cur_thread_id || thread_app_id != app_id {
-                        // Ignore this thread or the threads of other apps
-                        continue;
-                    }
-
-                    let thread_name =
-                        unsafe { CStr::from_ptr(sys::furi_thread_get_name(thread_id)) };
-
-                    if thread_name.to_bytes().ends_with(b"Srv") {
-                        // This is a workaround for an issue where the current appid matches
-                        // one of the built-in service names (e.g. "gui"). Otherwise we will
-                        // see the service thread (e.g. "GuiSrv") and assume that it's one of
-                        // our threads that still needs to exit, thus causing the app to hang
-                        // at exit.
-                        continue;
-                    }
-
-                    // There is a thread that is still running, so wait for it to exit...
-
-                    unsafe {
-                        sys::furi_delay_ms(10);
-                    }
-
-                    continue 'outer;
-                }
-
-                break;
-            }
-
-            unsafe {
-                sys::furi_log_print_format(
-                    sys::FuriLogLevel_FuriLogLevelDebug,
-                    sys::c_string!("flipperzero-rt"),
-                    sys::c_string!("All threads completed, exiting FAP"),
-                );
-            }
+            // Clean up app state.
+            $crate::__macro_support::__wait_for_thread_completion();
 
             ret
         }
     };
+}
+
+#[doc(hidden)]
+pub mod __macro_support {
+    /// ⚠️ WARNING: This is *not* a stable API! ⚠️
+    ///
+    /// This function, and all code contained in the `__macro_support` module, is a
+    /// *private* API of `flipperzero-rt`. It is exposed publicly because it is used by
+    /// the `flipperzero-rt` macros, but it is not part of the stable versioned API.
+    /// Breaking changes to this module may occur in small-numbered versions without
+    /// warning.
+    pub use crate::thread::wait_for_completion as __wait_for_thread_completion;
 }

--- a/crates/rt/src/thread.rs
+++ b/crates/rt/src/thread.rs
@@ -1,0 +1,65 @@
+use core::ffi::CStr;
+use core::ptr;
+
+use flipperzero_sys as sys;
+
+/// Wait for threads with the same app ID as the current thread to finish.
+///
+/// We assume there are not more than 30 threads running in the background outside this
+/// app, so we will observe at least one of any thread the app might have left running.
+pub fn wait_for_completion() {
+    unsafe {
+        sys::furi_log_print_format(
+            sys::FuriLogLevel_FuriLogLevelDebug,
+            sys::c_string!("flipperzero-rt"),
+            sys::c_string!("Waiting for FAP threads to complete..."),
+        );
+    }
+
+    const MAX_THREADS: usize = 32;
+    let cur_thread_id = unsafe { sys::furi_thread_get_current_id() };
+    let app_id = unsafe { CStr::from_ptr(sys::furi_thread_get_appid(cur_thread_id)) };
+    let mut thread_ids: [sys::FuriThreadId; MAX_THREADS] = [ptr::null_mut(); MAX_THREADS];
+
+    'outer: loop {
+        let thread_count =
+            unsafe { sys::furi_thread_enumerate(thread_ids.as_mut_ptr(), MAX_THREADS as u32) }
+                as usize;
+
+        for &thread_id in thread_ids[..thread_count].into_iter() {
+            let thread_app_id = unsafe { CStr::from_ptr(sys::furi_thread_get_appid(thread_id)) };
+
+            if thread_id == cur_thread_id || thread_app_id != app_id {
+                // Ignore this thread or the threads of other apps
+                continue;
+            }
+
+            let thread_name = unsafe { CStr::from_ptr(sys::furi_thread_get_name(thread_id)) };
+
+            if thread_name.to_bytes().ends_with(b"Srv") {
+                // This is a workaround for an issue where the current appid matches one
+                // of the built-in service names (e.g. "gui"). Otherwise we will see the
+                // service thread (e.g. "GuiSrv") and assume that it's one of our threads
+                // that still needs to exit, thus causing the app to hang at exit.
+                continue;
+            }
+
+            // There is a thread that is still running, so wait for it to exit...
+            unsafe {
+                sys::furi_delay_ms(10);
+            }
+
+            continue 'outer;
+        }
+
+        break;
+    }
+
+    unsafe {
+        sys::furi_log_print_format(
+            sys::FuriLogLevel_FuriLogLevelDebug,
+            sys::c_string!("flipperzero-rt"),
+            sys::c_string!("All FAP threads completed"),
+        );
+    }
+}


### PR DESCRIPTION
This tidies up the `entry!` macro and makes it easier to add other state cleanup functions later.