### PR TITLE
test: Support `#[cfg(..)]` attributes on test methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+### Changed
+- `flipperzero_test::tests` now allows `#[cfg(..)]` attributes on test methods.
 
 ## [0.10.0]
 ### Added


### PR DESCRIPTION
This is primarily to enable tests behind `#[cfg(feature = "alloc")]`, but may also be useful if we refactor to have services behind feature flags (https://github.com/flipperzero-rs/flipperzero/pull/29#discussion_r1059691569).