### PR TITLE
ci: use caching actions to setup build environment

### DIFF
--- a/.github/workflows/_build_and_test.yml
+++ b/.github/workflows/_build_and_test.yml
@@ -14,10 +14,14 @@ jobs:
       run:
         working-directory: ${{ inputs.target }}
     steps:
-    - uses: actions/checkout@v3
-    - run: sudo apt install libudev-dev
-    - name: Rustup
-      run: rustup +nightly target add thumbv7em-none-eabihf
+    - uses: actions/checkout@v3.5.2
+    - uses: awalsh128/cache-apt-pkgs-action@v1.3.0
+      with:
+        packages: libudev-dev
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: nightly
+        targets: x86_64-unknown-linux-gnu, thumbv7em-none-eabihf
     - name: Build
       run: cargo +nightly build --release --verbose
     - name: Build examples


### PR DESCRIPTION

# Description

This enables the usage of GitHub Actions which cache dependencies by default
in order to speed up builds.
