### PR TITLE
Fix gpio read always returning true

### DIFF
--- a/crates/flipperzero/examples/gpio.rs
+++ b/crates/flipperzero/examples/gpio.rs
@@ -37,8 +37,16 @@ fn main(_args: *mut u8) -> i32 {
 
         sleep(Duration::from_secs(1));
 
+        let state = sys::furi_hal_gpio_read(&sys::gpio_ext_pc0);
+        println!("Pin C0 is {}", if state { "high" } else { "low" });
+
         println!("Pulling pin C0 low");
         sys::furi_hal_gpio_write(&sys::gpio_ext_pc0, false);
+
+        sleep(Duration::from_secs(1));
+
+        let state = sys::furi_hal_gpio_read(&sys::gpio_ext_pc0);
+        println!("Pin C0 is {}", if state { "high" } else { "low" });
     }
 
     0

--- a/crates/sys/src/inlines/furi_hal_gpio.rs
+++ b/crates/sys/src/inlines/furi_hal_gpio.rs
@@ -34,7 +34,10 @@ pub unsafe extern "C" fn furi_hal_gpio_write_port_pin(
     state: bool,
 ) {
     // writing to BSSR is an atomic operation
-    (*port).BSRR = (pin as u32) << if state { 0 } else { GPIO_NUMBER };
+    core::ptr::write_volatile(
+        &mut (*port).BSRR,
+        (pin as u32) << if state { 0 } else { GPIO_NUMBER },
+    );
 }
 
 /// GPIO read pin.
@@ -60,5 +63,5 @@ pub unsafe extern "C" fn furi_hal_gpio_read_port_pin(
     port: *mut sys::GPIO_TypeDef,
     pin: u16,
 ) -> bool {
-    (*port).IDR & pin as u32 != 0x00
+    core::ptr::read_volatile(&(*port).IDR) & pin as u32 != 0x00
 }

--- a/crates/sys/src/inlines/furi_hal_gpio.rs
+++ b/crates/sys/src/inlines/furi_hal_gpio.rs
@@ -60,5 +60,5 @@ pub unsafe extern "C" fn furi_hal_gpio_read_port_pin(
     port: *mut sys::GPIO_TypeDef,
     pin: u16,
 ) -> bool {
-    (*port).IDR != 0 && pin != 0x00
+    (*port).IDR & pin as u32 != 0x00
 }


### PR DESCRIPTION
Also make register manipulations volatile as the original `furi` hal functions are.
Updated the GPIO example to verify that the actual state was being returned.