### PR TITLE
Update test harness for upstream changes to loader

### DIFF
--- a/crates/test/macros/src/lib.rs
+++ b/crates/test/macros/src/lib.rs
@@ -124,15 +124,17 @@ fn tests_runner_impl(args: TokenStream) -> parse::Result<TokenStream> {
                 ret
             }
 
-            fn test_list() -> impl Iterator<Item = (&'static str, &'static str, ::flipperzero_test::TestFn)> {
+            fn test_list() -> impl Iterator<Item = (&'static str, &'static str, ::flipperzero_test::TestFn)> + Clone {
                 let ret = ::core::iter::empty();
                 #( let ret = ret.chain(#test_lists); )*
                 ret
             }
 
             // Test runner entry point
-            fn main(_args: *mut u8) -> i32 {
-                match ::flipperzero_test::__macro_support::run_tests(test_count(), test_list()) {
+            fn main(args: *mut u8) -> i32 {
+                // SAFETY: Flipper Zero passes arguments to FAPs as a C string.
+                let args = unsafe { ::flipperzero_test::__macro_support::Args::parse(args) };
+                match ::flipperzero_test::__macro_support::run_tests(test_count(), test_list(), args) {
                     Ok(()) => 0,
                     Err(e) => e,
                 }

--- a/tools/src/bin/run-fap.rs
+++ b/tools/src/bin/run-fap.rs
@@ -115,7 +115,7 @@ fn main() -> Result<(), Error> {
     wait_for_idle(serial_cli)?;
 
     // Run the FAP.
-    serial_cli.send_and_wait_eol(&format!("loader open Applications {}", dest_file))?;
+    serial_cli.send_and_wait_eol(&format!("loader open {}", dest_file))?;
 
     // Wait for the FAP to finish.
     wait_for_idle(serial_cli)?;

--- a/tools/src/bin/run-fap.rs
+++ b/tools/src/bin/run-fap.rs
@@ -115,7 +115,7 @@ fn main() -> Result<(), Error> {
     wait_for_idle(serial_cli)?;
 
     // Run the FAP.
-    serial_cli.send_and_wait_eol(&format!("loader open {}", dest_file))?;
+    serial_cli.send_and_wait_eol(&format!("loader open {} {}", dest_file, cli.args.join(" ")))?;
 
     // Wait for the FAP to finish.
     wait_for_idle(serial_cli)?;


### PR DESCRIPTION
This now enables test filtering:
```
$ cd crates/
$ cargo test -- FILTER ANOTHER_FILTER
```