### PR TITLE
flipperzero: Enable Miri to start running the tests

### DIFF
--- a/crates/.cargo/config.toml
+++ b/crates/.cargo/config.toml
@@ -1,6 +1,10 @@
+# Equivalent to [target.thumbv7em-none-eabihf] but also disabing the runner for Miri.
+# Until target_abi is stable, this also permits thumbv7em-none-eabi.
+[target.'cfg(all(target_arch = "arm", target_feature = "thumb2", target_feature = "v7", target_feature = "dsp", target_os = "none", not(miri)))']
+runner = "python3 ../cargo-runner.py"
+
 [target.thumbv7em-none-eabihf]
 linker = "./fap-lld.py"
-runner = "python3 ../cargo-runner.py"
 rustflags = [
     # CPU is Cortex-M4 (STM32WB55)
     "-C", "target-cpu=cortex-m4",

--- a/crates/.cargo/config.toml
+++ b/crates/.cargo/config.toml
@@ -1,6 +1,5 @@
 # Equivalent to [target.thumbv7em-none-eabihf] but also disabing the runner for Miri.
-# Until target_abi is stable, this also permits thumbv7em-none-eabi.
-[target.'cfg(all(target_arch = "arm", target_feature = "thumb2", target_feature = "v7", target_feature = "dsp", target_os = "none", not(miri)))']
+[target.'cfg(all(target_arch = "arm", target_feature = "thumb2", target_feature = "v7", target_feature = "dsp", target_os = "none", target_abi = "eabihf", not(miri)))']
 runner = "python3 ../cargo-runner.py"
 
 [target.thumbv7em-none-eabihf]

--- a/crates/flipperzero/src/furi/thread.rs
+++ b/crates/flipperzero/src/furi/thread.rs
@@ -206,6 +206,7 @@ pub fn sleep(duration: core::time::Duration) {
 /// A unique identifier for a running thread.
 #[cfg(feature = "alloc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+#[allow(dead_code)]
 pub struct ThreadId(sys::FuriThreadId);
 
 /// A handle to a thread.

--- a/crates/flipperzero/src/gpio/i2c.rs
+++ b/crates/flipperzero/src/gpio/i2c.rs
@@ -1,6 +1,7 @@
 //! I2C interface for the Flipper Zero.
 
 use core::fmt;
+use core::ptr::addr_of_mut;
 
 use flipperzero_sys as sys;
 
@@ -99,9 +100,12 @@ impl Bus {
     ///
     /// Blocks indefinitely until the bus is available.
     pub fn acquire(self) -> BusHandle {
+        // SAFETY: We block until we acquire a handle to the selected bus, so nothing else
+        // will be using it while we have a raw pointer to it. We don't convert this to a
+        // `&'static mut` reference because this will be disallowed in Rust 2024 edition.
         BusHandle::acquire(match self.0 {
-            BusKind::Internal => unsafe { &mut sys::furi_hal_i2c_handle_power },
-            BusKind::External => unsafe { &mut sys::furi_hal_i2c_handle_external },
+            BusKind::Internal => unsafe { addr_of_mut!(sys::furi_hal_i2c_handle_power) },
+            BusKind::External => unsafe { addr_of_mut!(sys::furi_hal_i2c_handle_external) },
         })
     }
 
@@ -115,7 +119,7 @@ impl Bus {
 
 /// A handle to an I2C bus on the Flipper Zero.
 pub struct BusHandle {
-    handle: &'static mut sys::FuriHalI2cBusHandle,
+    handle: *mut sys::FuriHalI2cBusHandle,
 }
 
 impl Drop for BusHandle {
@@ -128,7 +132,7 @@ impl BusHandle {
     /// Acquires a handle to the given I2C bus.
     ///
     /// Blocks indefinitely until the Flipper Zero bus is locally available.
-    fn acquire(handle: &'static mut sys::FuriHalI2cBusHandle) -> Self {
+    fn acquire(handle: *mut sys::FuriHalI2cBusHandle) -> Self {
         unsafe { sys::furi_hal_i2c_acquire(handle) };
         Self { handle }
     }

--- a/crates/flipperzero/src/lib.rs
+++ b/crates/flipperzero/src/lib.rs
@@ -5,7 +5,8 @@
 //!
 
 #![no_std]
-#![cfg_attr(test, no_main)]
+#![cfg_attr(all(test, not(miri)), no_main)]
+#![cfg_attr(all(test, miri), feature(start))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(rustdoc::broken_intra_doc_links)]
 

--- a/crates/flipperzero/src/storage.rs
+++ b/crates/flipperzero/src/storage.rs
@@ -146,6 +146,7 @@ impl OpenOptions {
 }
 
 /// Basic, unbuffered file handle
+#[allow(dead_code)]
 pub struct File(NonNull<sys::File>, UnsafeRecord<sys::Storage>);
 
 impl File {

--- a/crates/rt/src/lib.rs
+++ b/crates/rt/src/lib.rs
@@ -34,6 +34,7 @@ macro_rules! entry {
     ($path:path) => {
         // Force the section to `.text` instead of `.text.main`.
         // lld seems not to automatically rename `.rel.text.main` properly.
+        #[cfg(not(miri))]
         #[export_name = "main"]
         pub unsafe fn __main(args: *mut u8) -> i32 {
             // type check the entry function

--- a/crates/rust-toolchain.toml
+++ b/crates/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2023-12-09"
+channel = "nightly-2024-04-16"
 targets = [ "thumbv7em-none-eabihf" ]
 components = [ "clippy", "rustfmt" ]

--- a/crates/sys/src/lib.rs
+++ b/crates/sys/src/lib.rs
@@ -5,13 +5,16 @@
 
 // Features that identify thumbv7em-none-eabihf.
 // Until target_abi is stable, this also permits thumbv7em-none-eabi.
-#[cfg(not(all(
-    target_arch = "arm",
-    target_feature = "thumb2",
-    target_feature = "v7",
-    target_feature = "dsp",
-    target_os = "none",
-    //target_abi = "eabihf",
+#[cfg(not(any(
+    all(
+        target_arch = "arm",
+        target_feature = "thumb2",
+        target_feature = "v7",
+        target_feature = "dsp",
+        target_os = "none",
+        //target_abi = "eabihf",
+    ),
+    miri
 )))]
 core::compile_error!("This crate requires `--target thumbv7em-none-eabihf`");
 

--- a/crates/sys/src/lib.rs
+++ b/crates/sys/src/lib.rs
@@ -4,7 +4,6 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 
 // Features that identify thumbv7em-none-eabihf.
-// Until target_abi is stable, this also permits thumbv7em-none-eabi.
 #[cfg(not(any(
     all(
         target_arch = "arm",
@@ -12,7 +11,7 @@
         target_feature = "v7",
         target_feature = "dsp",
         target_os = "none",
-        //target_abi = "eabihf",
+        target_abi = "eabihf",
     ),
     miri
 )))]


### PR DESCRIPTION
It doesn't *successfully* run the tests because Miri doesn't yet support FFI, but these changes enable the following command to actually start:

    MIRI_NO_STD=1 cargo miri test --target thumbv7em-none-eabihf

Part of flipperzero-rs/flipperzero#100.