### PR TITLE
rt: Change type signature of entry point to be safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `flipperzero_rt::entry` macro now requires a function with type signature
   `fn(Option<&CStr>) -> i32` instead of `fn(*mut u8) -> i32`.
 
+### Removed
+
+- `flipperzero::toolbox::{Md5, Sha256}` (due to their removal from the Flipper
+  Zero SDK API).
+
 ## [0.11.0]
 
 ### Added
@@ -30,10 +35,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Migrated to SDK API 35.0 (firmware 0.89.0).
 - `flipperzero_test::tests` now allows `#[cfg(..)]` attributes on test methods.
-
-### Removed
-
-- `md5` and `sha256` toolbox APIs due to their removal from the firmware API.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - Migrated to SDK 50.0 (firmware 0.97.1).
+- `flipperzero_rt::entry` macro now requires a function with type signature
+  `fn(Option<&CStr>) -> i32` instead of `fn(*mut u8) -> i32`.
 
 ## [0.11.0]
 

--- a/crates/flipperzero/examples/dialog.rs
+++ b/crates/flipperzero/examples/dialog.rs
@@ -22,7 +22,7 @@ use flipperzero_rt::{entry, manifest};
 manifest!(name = "Rust dialog example");
 entry!(main);
 
-fn main(_args: *mut u8) -> i32 {
+fn main(_args: Option<&CStr>) -> i32 {
     // To customize the dialog, use the DialogMessage API:
     let mut dialogs = DialogsApp::open();
     let mut message = DialogMessage::new();

--- a/crates/flipperzero/examples/example_images.rs
+++ b/crates/flipperzero/examples/example_images.rs
@@ -4,7 +4,7 @@
 #![no_std]
 #![no_main]
 
-use core::ffi::{c_char, c_void};
+use core::ffi::{c_char, c_void, CStr};
 use core::mem::{self, MaybeUninit};
 
 use flipperzero_rt as rt;
@@ -65,7 +65,7 @@ extern "C" fn app_input_callback(input_event: *mut sys::InputEvent, ctx: *mut c_
     }
 }
 
-fn main(_args: *mut u8) -> i32 {
+fn main(_args: Option<&CStr>) -> i32 {
     unsafe {
         let event_queue = sys::furi_message_queue_alloc(8, mem::size_of::<sys::InputEvent>() as u32)
             as *mut sys::FuriMessageQueue;

--- a/crates/flipperzero/examples/gpio.rs
+++ b/crates/flipperzero/examples/gpio.rs
@@ -13,6 +13,7 @@ extern crate flipperzero_rt;
 #[cfg(feature = "alloc")]
 extern crate flipperzero_alloc;
 
+use core::ffi::CStr;
 use core::time::Duration;
 
 use flipperzero::furi::thread::sleep;
@@ -27,7 +28,7 @@ manifest!(name = "Rust GPIO example");
 entry!(main);
 
 // Entry point
-fn main(_args: *mut u8) -> i32 {
+fn main(_args: Option<&CStr>) -> i32 {
     unsafe {
         println!("Configuring pin C0 as output pin");
         sys::furi_hal_gpio_init_simple(&sys::gpio_ext_pc0, sys::GpioMode_GpioModeOutputPushPull);

--- a/crates/flipperzero/examples/gui.rs
+++ b/crates/flipperzero/examples/gui.rs
@@ -14,7 +14,7 @@ extern crate flipperzero_rt;
 #[cfg(feature = "alloc")]
 extern crate flipperzero_alloc;
 
-use core::ffi::{c_char, c_void};
+use core::ffi::{c_char, c_void, CStr};
 use core::ptr;
 use core::time::Duration;
 
@@ -36,7 +36,7 @@ pub unsafe extern "C" fn draw_callback(canvas: *mut sys::Canvas, _context: *mut 
     }
 }
 
-fn main(_args: *mut u8) -> i32 {
+fn main(_args: Option<&CStr>) -> i32 {
     // Currently there is no high level GUI bindings,
     // so this all has to be done using the `sys` bindings.
     unsafe {

--- a/crates/flipperzero/examples/hello-rust.rs
+++ b/crates/flipperzero/examples/hello-rust.rs
@@ -11,6 +11,8 @@ extern crate flipperzero_rt;
 #[cfg(feature = "alloc")]
 extern crate flipperzero_alloc;
 
+use core::ffi::CStr;
+
 use flipperzero::{debug, info, println};
 use flipperzero_rt::{entry, manifest};
 
@@ -27,7 +29,7 @@ manifest!(
 entry!(main);
 
 // Entry point
-fn main(_args: *mut u8) -> i32 {
+fn main(_args: Option<&CStr>) -> i32 {
     info!("Hello, reader of the logs!");
     println!("Hello, {}!", "Rust");
 

--- a/crates/flipperzero/examples/i2c-ds3231.rs
+++ b/crates/flipperzero/examples/i2c-ds3231.rs
@@ -12,6 +12,8 @@ extern crate flipperzero_rt;
 #[cfg(feature = "alloc")]
 extern crate flipperzero_alloc;
 
+use core::ffi::CStr;
+
 use flipperzero::{error, furi::time::Duration, gpio::i2c, println};
 use flipperzero_rt::{entry, manifest};
 use ufmt::derive::uDebug;
@@ -61,7 +63,7 @@ impl RtcTime {
     }
 }
 
-fn main(_args: *mut u8) -> i32 {
+fn main(_args: Option<&CStr>) -> i32 {
     let mut bus = i2c::Bus::EXTERNAL.acquire();
     let rtc = i2c::DeviceAddress::new(0x68);
     let timeout = Duration::from_millis(50);

--- a/crates/flipperzero/examples/notification.rs
+++ b/crates/flipperzero/examples/notification.rs
@@ -9,6 +9,7 @@ extern crate flipperzero_rt;
 // Required for allocator
 extern crate flipperzero_alloc;
 
+use core::ffi::CStr;
 use core::time::Duration;
 
 use flipperzero::{
@@ -24,7 +25,7 @@ manifest!(name = "Rust notification example");
 entry!(main);
 
 // Entry point
-fn main(_args: *mut u8) -> i32 {
+fn main(_args: Option<&CStr>) -> i32 {
     let mut app = NotificationService::open();
 
     // Set the notification LED to different colours

--- a/crates/flipperzero/examples/storage.rs
+++ b/crates/flipperzero/examples/storage.rs
@@ -23,7 +23,7 @@ use flipperzero_rt::{entry, manifest};
 manifest!(name = "Rust storage example");
 entry!(main);
 
-fn main(_args: *mut u8) -> i32 {
+fn main(_args: Option<&CStr>) -> i32 {
     // First, we'll create a file on the SD card and write "Hello, Rust!" to it.
     let path = CStr::from_bytes_with_nul(b"/ext/hello-rust.txt\0").unwrap();
     let file = OpenOptions::new()

--- a/crates/flipperzero/examples/threads.rs
+++ b/crates/flipperzero/examples/threads.rs
@@ -13,6 +13,7 @@ extern crate flipperzero_alloc;
 extern crate alloc;
 
 use alloc::borrow::ToOwned;
+use core::ffi::CStr;
 use core::time::Duration;
 
 use flipperzero::{furi::thread, println};
@@ -25,7 +26,7 @@ manifest!(name = "Threads example");
 entry!(main);
 
 // Entry point
-fn main(_args: *mut u8) -> i32 {
+fn main(_args: Option<&CStr>) -> i32 {
     println!("Main app started!");
 
     let first = thread::spawn(|| {

--- a/crates/flipperzero/examples/view_dispatcher.rs
+++ b/crates/flipperzero/examples/view_dispatcher.rs
@@ -78,7 +78,7 @@ pub unsafe extern "C" fn navigation_event_callback(context: *mut c_void) -> bool
     true
 }
 
-fn main(_args: *mut u8) -> i32 {
+fn main(_args: Option<&CStr>) -> i32 {
     let mut app = App::new();
 
     unsafe {

--- a/crates/rt/src/lib.rs
+++ b/crates/rt/src/lib.rs
@@ -11,6 +11,7 @@ pub mod panic_handler;
 mod thread;
 
 /// The C entry point.
+///
 /// This just delegates to the user's Rust entry point.
 ///
 /// # Safety
@@ -25,8 +26,9 @@ pub unsafe extern "C" fn _start(args: *mut u8) -> i32 {
     main(args)
 }
 
-/// Define the entry point.
-/// Must have the following signature: `fn(*mut u8) -> i32`.
+/// Defines the entry point.
+///
+/// Must have the following signature: `fn(Option<&CStr>) -> i32`.
 #[macro_export]
 macro_rules! entry {
     ($path:path) => {
@@ -35,7 +37,15 @@ macro_rules! entry {
         #[export_name = "main"]
         pub unsafe fn __main(args: *mut u8) -> i32 {
             // type check the entry function
-            let f: fn(*mut u8) -> i32 = $path;
+            let f: fn(Option<&::core::ffi::CStr>) -> i32 = $path;
+
+            let args = if args.is_null() {
+                None
+            } else {
+                // SAFETY: Flipper Zero passes arguments to FAPs as a C string.
+                let args = unsafe { core::ffi::CStr::from_ptr(args.cast_const().cast()) };
+                Some(args)
+            };
 
             let ret = f(args);
 

--- a/crates/test/macros/src/lib.rs
+++ b/crates/test/macros/src/lib.rs
@@ -131,9 +131,8 @@ fn tests_runner_impl(args: TokenStream) -> parse::Result<TokenStream> {
             }
 
             // Test runner entry point
-            fn main(args: *mut u8) -> i32 {
-                // SAFETY: Flipper Zero passes arguments to FAPs as a C string.
-                let args = unsafe { ::flipperzero_test::__macro_support::Args::parse(args) };
+            fn main(args: Option<&::core::ffi::CStr>) -> i32 {
+                let args = ::flipperzero_test::__macro_support::Args::parse(args);
                 match ::flipperzero_test::__macro_support::run_tests(test_count(), test_list(), args) {
                     Ok(()) => 0,
                     Err(e) => e,

--- a/crates/test/src/lib.rs
+++ b/crates/test/src/lib.rs
@@ -77,39 +77,12 @@ pub mod __macro_support {
     pub struct Args<'a>(&'a str);
 
     impl<'a> Args<'a> {
-        /// Parses test arguments from a raw C string.
-        ///
-        /// The total size of the raw C string must be smaller than `isize::MAX` **bytes**
-        /// in memory due to calling the `slice::from_raw_parts` function.
-        ///
-        /// If the C string does not contain valid UTF-8, it is ignored and the test is
-        /// run without arguments.
-        ///
-        /// # Safety
-        ///
-        /// * The memory pointed to by `ptr` must contain a valid nul terminator at the
-        ///   end of the string.
-        ///
-        /// * `ptr` must be [valid] for reads of bytes up to and including the null
-        ///   terminator. This means in particular that the entire memory range of the C
-        ///   string must be contained within a single allocated object!
-        ///
-        /// * The memory referenced by the returned `CStr` must not be mutated for
-        ///   the duration of lifetime `'a`.
-        ///
-        /// # Caveat
-        ///
-        /// The lifetime for the returned slice is inferred from its usage.
-        ///
-        /// [valid]: core::ptr#safety
-        pub unsafe fn parse(args: *mut u8) -> Self {
-            if args.is_null() {
-                Args("")
-            } else {
-                let args_cstr = unsafe { CStr::from_ptr(args.cast_const().cast()) };
-                let args = args_cstr.to_str().unwrap_or("");
-                Args(args)
-            }
+        /// Parses test arguments from a C string.
+        pub fn parse(args: Option<&'a CStr>) -> Self {
+            let args = args
+                .and_then(|args_cstr| args_cstr.to_str().ok())
+                .unwrap_or("");
+            Args(args)
         }
 
         fn filters(&self) -> Filters<'a> {


### PR DESCRIPTION
The argument C string pointer is now handled internally instead of in user code.