### PR TITLE
Allow access to internal C FuriString

### DIFF
--- a/crates/flipperzero/src/furi/string.rs
+++ b/crates/flipperzero/src/furi/string.rs
@@ -7,6 +7,7 @@ use core::{
     ffi::{c_char, CStr},
     fmt::{self, Write},
     hash,
+    mem::ManuallyDrop,
     ops::{Add, AddAssign},
     ptr::{self, NonNull},
 };
@@ -72,6 +73,18 @@ impl FuriString {
         // terminator.
         unsafe { sys::furi_string_reserve(s.0.as_ptr(), capacity + 1) };
         s
+    }
+
+    /// Consume the [`FuriString`] and return the internal [`sys::FuriString`].
+    /// You are responsible for freeing the returned [`sys::FuriString`] using
+    /// [`sys::furi_string_free`] or similar API.
+    #[inline]
+    #[must_use]
+    pub fn into_raw(self) -> NonNull<sys::FuriString> {
+        // Inhibit calling of the `Drop` trait
+        let s = ManuallyDrop::new(self);
+
+        s.0
     }
 
     #[inline]

--- a/crates/flipperzero/src/furi/string.rs
+++ b/crates/flipperzero/src/furi/string.rs
@@ -87,10 +87,11 @@ impl FuriString {
         unsafe { CStr::from_ptr(self.as_c_ptr()) }
     }
 
-    /// Raw pointer to the inner sys::FuriString
+    /// Raw pointer to the inner [`sys::FuriString`].
+    /// You must not deallocate, free or otherwise invalidate this pointer otherwise undefined behaviour will result.
     #[inline]
     #[must_use]
-    pub(crate) fn as_mut_ptr(&mut self) -> *mut sys::FuriString {
+    pub fn as_mut_ptr(&mut self) -> *mut sys::FuriString {
         self.0.as_ptr()
     }
 


### PR DESCRIPTION
This is required as there are certain APIs that are not accessible through safe Rust bindings (e.g. `furi_string_printf` is variadic).

Both functions are safe because you can't use it to perform any unsafe operations without making an unsafe action  such as dereferencing or passing to a C function.