### PR TITLE
tools: Create temporary directories under `/ext/.tmp`

### DIFF
--- a/tools/src/bin/run-fap.rs
+++ b/tools/src/bin/run-fap.rs
@@ -100,7 +100,7 @@ fn main() -> Result<(), Error> {
 
     // Upload the FAP to a temporary directory.
     let dest_dir =
-        storage::FlipperPath::from(format!("/ext/tmp-{:08x}", thread_rng().gen::<u32>()));
+        storage::FlipperPath::from(format!("/ext/.tmp/rs-{:08x}", thread_rng().gen::<u32>()));
     let dest_file = dest_dir.clone() + file_name;
     store
         .mkdir(&dest_dir)


### PR DESCRIPTION
This prevents them from polluting the main `/ext` directory when a runner aborts partway through without deleting the tempdir.