### PR TITLE
ci: enable automatic SDK Update PR creation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 tools/Dockerfile
 tools/target
 crates/target
+.direnv

--- a/.github/workflows/_build_and_test.yml
+++ b/.github/workflows/_build_and_test.yml
@@ -26,5 +26,4 @@ jobs:
       run: |
         cargo test --release --verbose 2>&1 | tee stderr.txt
     - name: Check that tests failed for the expected reason
-      run: |
-        cat stderr.txt | grep -q "Error: unable to find Flipper Zero"
+      run: '< stderr.txt grep -q "Error: unable to find Flipper Zero"'

--- a/.github/workflows/_build_and_test.yml
+++ b/.github/workflows/_build_and_test.yml
@@ -15,7 +15,7 @@ jobs:
       run:
         working-directory: ${{ inputs.target }}
     steps:
-    - uses: actions/checkout@v4.1.7
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - run: rustup component add llvm-tools
     - run: sudo apt install libudev-dev
     - name: Build

--- a/.github/workflows/_lints.yml
+++ b/.github/workflows/_lints.yml
@@ -15,11 +15,11 @@ jobs:
       run:
         working-directory: ${{ inputs.target }}
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Install build dependencies
         run: sudo apt install libudev-dev
       - name: Run Clippy
-        uses: auguwu/clippy-action@1.4.0
+        uses: auguwu/clippy-action@94a9ff2f6920180b89e5c03d121d0af04a9d3e03 # 1.4.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: ${{ inputs.target }}
@@ -36,7 +36,7 @@ jobs:
       run:
         working-directory: ${{ inputs.target }}
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Install build dependencies
         run: sudo apt install libudev-dev
       - uses: dtolnay/rust-toolchain@beta
@@ -45,7 +45,7 @@ jobs:
           components: clippy
       - run: rustup override set ${{ steps.toolchain.outputs.name }}
       - name: Run Clippy (beta)
-        uses: auguwu/clippy-action@1.4.0
+        uses: auguwu/clippy-action@94a9ff2f6920180b89e5c03d121d0af04a9d3e03 # 1.4.0
         continue-on-error: true
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -62,7 +62,7 @@ jobs:
       run:
         working-directory: ${{ inputs.target }}
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Install build dependencies
         run: sudo apt install libudev-dev
       # Use nightly Rust (as docs.rs does), because some of our dependencies enable the
@@ -86,5 +86,5 @@ jobs:
       run:
         working-directory: ${{ inputs.target }}
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - run: cargo fmt --all --check

--- a/.github/workflows/update_bindings.yml
+++ b/.github/workflows/update_bindings.yml
@@ -37,7 +37,6 @@ jobs:
         id: generate-bindings
         uses: docker/build-push-action@16ebe778df0e7752d2cfcbd924afdbbd89c1a755 # v6.6.1
         with:
-          tags: flipperzero-sdk-bindings:latest
           context: .
           load: true
           build-args: 'BRANCH=${{ github.event.inputs.sdk_version }}'

--- a/.github/workflows/update_bindings.yml
+++ b/.github/workflows/update_bindings.yml
@@ -23,19 +23,19 @@ jobs:
         run: echo '${{ github.event.inputs.sdk_version }}' | grep --perl-regexp '^\d+\.\d+\.\d+$'
       -
         name: Checkout sources
-        uses: actions/checkout@v4.1.2
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: main
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.6.1
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
       -
         name: Create branch
         run: git checkout -b'github-actions/update-bindings/sdk/${{ github.event.inputs.sdk_version }}'
       -
         name: Generate bindings
         id: generate-bindings
-        uses: docker/build-push-action@v6.6.1
+        uses: docker/build-push-action@16ebe778df0e7752d2cfcbd924afdbbd89c1a755 # v6.6.1
         with:
           tags: flipperzero-sdk-bindings:latest
           context: .

--- a/.github/workflows/update_bindings.yml
+++ b/.github/workflows/update_bindings.yml
@@ -65,8 +65,7 @@ jobs:
             --base='main' \
             --title='build(bindings): bump SDK to `${{ github.event.inputs.sdk_version }}`' \
             --body="${PULL_REQUEST_DESCRIPTION}" \
-            --label='sdk-update' \
-            --reviewer='flipperzero-rs/maintainers'
+            --label='sdk-update'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PULL_REQUEST_DESCRIPTION: >-

--- a/.github/workflows/update_bindings.yml
+++ b/.github/workflows/update_bindings.yml
@@ -21,12 +21,9 @@ jobs:
       -
         name: Validate SDK version
         run: echo '${{ github.event.inputs.sdk_version }}' | grep --perl-regexp '^\d+\.\d+\.\d+$'
-      # Workaround for `generate-bindings` step failing on load due to `no space left on device` error
       -
         name: Checkout sources
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-        with:
-          ref: main
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
@@ -42,6 +39,8 @@ jobs:
           load: true
           build-args: 'BRANCH=${{ github.event.inputs.sdk_version }}'
           file: tools/Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       -
         name: Copy bindings
         run: |

--- a/.github/workflows/update_bindings.yml
+++ b/.github/workflows/update_bindings.yml
@@ -21,6 +21,9 @@ jobs:
       -
         name: Validate SDK version
         run: echo '${{ github.event.inputs.sdk_version }}' | grep --perl-regexp '^\d+\.\d+\.\d+$'
+      # Workaround for `generate-bindings` step failing on load due to `no space left on device` error
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
       -
         name: Checkout sources
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/update_bindings.yml
+++ b/.github/workflows/update_bindings.yml
@@ -22,8 +22,6 @@ jobs:
         name: Validate SDK version
         run: echo '${{ github.event.inputs.sdk_version }}' | grep --perl-regexp '^\d+\.\d+\.\d+$'
       # Workaround for `generate-bindings` step failing on load due to `no space left on device` error
-      - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
       -
         name: Checkout sources
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -44,8 +42,6 @@ jobs:
           load: true
           build-args: 'BRANCH=${{ github.event.inputs.sdk_version }}'
           file: tools/Dockerfile
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
       -
         name: Copy bindings
         run: |

--- a/.github/workflows/update_bindings.yml
+++ b/.github/workflows/update_bindings.yml
@@ -42,8 +42,11 @@ jobs:
           build-args: 'BRANCH=${{ github.event.inputs.sdk_version }}'
           file: tools/Dockerfile
       -
-        name: Update bindings
-        run: docker run ${{ steps.generate-bindings.outputs.imageid }} > crates/sys/src/bindings.rs
+        name: Copy bindings
+        run: |
+          container="$(docker container create ${{ steps.generate-bindings.outputs.imageid }} --read-only)"
+          docker container cp "${container}":bindings.rs ./crates/sys/src/bindings.rs
+          docker container rm "${container}"
       -
         name: Commit changes
         run: |

--- a/.github/workflows/update_bindings.yml
+++ b/.github/workflows/update_bindings.yml
@@ -1,0 +1,87 @@
+name: Update Bindings
+
+on:
+  workflow_dispatch:
+    inputs:
+      sdk_version:
+        description: flipperzero-firmware SDK version
+        type: string
+        required: true
+
+jobs:
+  sdk:
+    name: Update SDK bindings
+    runs-on: ubuntu-latest
+    permissions:
+      # SAFETY: A commit authored by the Bot will be pushed
+      contents: write
+      # SAFETY: An update PR will be created by the Bot
+      pull-requests: write
+    steps:
+      -
+        name: Validate SDK version
+        run: echo '${{ github.event.inputs.sdk_version }}' | grep --perl-regexp '^\d+\.\d+\.\d+$'
+      -
+        name: Checkout sources
+        uses: actions/checkout@v4.1.2
+        with:
+          ref: main
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.6.1
+      -
+        name: Create branch
+        run: git checkout -b'github-actions/update-bindings/sdk/${{ github.event.inputs.sdk_version }}'
+      -
+        name: Generate bindings
+        id: generate-bindings
+        uses: docker/build-push-action@v6.6.1
+        with:
+          tags: flipperzero-sdk-bindings:latest
+          context: .
+          load: true
+          build-args: 'BRANCH=${{ github.event.inputs.sdk_version }}'
+          file: tools/Dockerfile
+      -
+        name: Update bindings
+        run: docker run ${{ steps.generate-bindings.outputs.imageid }} > crates/sys/src/bindings.rs
+      -
+        name: Commit changes
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git commit crates/sys/src/bindings.rs \
+            --message='build(bindings): bump SDK to `${{ github.event.inputs.sdk_version }}`'
+      -
+        name: Push changes
+        run: git push --set-upstream origin 'github-actions/update-bindings/sdk/${{ github.event.inputs.sdk_version }}'
+      -
+        name: Create update Pull Request
+        run: |
+          gh pr create \
+            --repo='flipperzero-rs/flipperzero' \
+            --base='main' \
+            --title='build(bindings): bump SDK to `${{ github.event.inputs.sdk_version }}`' \
+            --body="${PULL_REQUEST_DESCRIPTION}" \
+            --label='sdk-update' \
+            --reviewer='flipperzero-rs/maintainers'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_REQUEST_DESCRIPTION: >-
+            # Description
+
+
+            This updates SDK bindings to [`${{ github.event.inputs.sdk_version }}`][1].
+
+
+            ---
+
+
+            This PR has been automatically created by user @${{ github.triggering_actor }}
+            via `${{ github.workflow }}` workflow.
+
+
+            Further changes may added to this pull request.
+
+
+            [1]: https://github.com/flipperdevices/flipperzero-firmware/releases/tag/${{ github.event.inputs.sdk_version }}

--- a/.github/workflows/update_bindings.yml
+++ b/.github/workflows/update_bindings.yml
@@ -41,6 +41,8 @@ jobs:
           load: true
           build-args: 'BRANCH=${{ github.event.inputs.sdk_version }}'
           file: tools/Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       -
         name: Copy bindings
         run: |

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,2 @@
+files:
+  - pattern: "^\\.github/workflows/.*\\.ya?ml$"

--- a/docs/updating-sdk.md
+++ b/docs/updating-sdk.md
@@ -36,7 +36,10 @@ Alternatively, you can generate `binding.rs` in an isolated env using Docker and
 From the root of the repository, to build the binding for the branch/tag `0.102.3` of the official SDK:
 
 ```shell
-docker run --rm $(docker build --build-arg BRANCH=0.102.3 -q -f tools/Dockerfile .) > crates/sys/src/bindings.rs
+image="$(docker build --build-arg BRANCH=0.102.3 --quiet --file tools/Dockerfile .)"
+container="$(docker container create --read-only "${image}")"
+docker container cp "${container}":bindings.rs ./crates/sys/src/bindings.rs
+docker container rm "${container}"
 ```
 
 [`bindings.rs`]: ../crates/sys/src/bindings.rs

--- a/flake.nix
+++ b/flake.nix
@@ -15,8 +15,12 @@
           inherit system;
           overlays = [ rust-overlay.overlays.default ];
         };
-        rust = pkgs.rust-bin.fromRustupToolchainFile ./crates/rust-toolchain.toml;
+        rust =
+          pkgs.rust-bin.fromRustupToolchainFile ./crates/rust-toolchain.toml;
       in {
-        devShells.default = pkgs.mkShell { nativeBuildInputs = [ rust pkgs.python3]; };
+        devShells = {
+          default = pkgs.mkShell { nativeBuildInputs = [ rust pkgs.python3 ]; };
+          github-actions = pkgs.mkShell { nativeBuildInputs = [ pkgs.act pkgs.actionlint ]; };
+        };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -8,19 +8,39 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
-  outputs = { nixpkgs, flake-utils, rust-overlay, ... }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      nixpkgs,
+      flake-utils,
+      rust-overlay,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = import nixpkgs {
           inherit system;
           overlays = [ rust-overlay.overlays.default ];
         };
-        rust =
-          pkgs.rust-bin.fromRustupToolchainFile ./crates/rust-toolchain.toml;
-      in {
+        rust = pkgs.rust-bin.fromRustupToolchainFile ./crates/rust-toolchain.toml;
+      in
+      {
+        formatter = pkgs.nixfmt-rfc-style;
         devShells = {
-          default = pkgs.mkShell { nativeBuildInputs = [ rust pkgs.python3 ]; };
-          github-actions = pkgs.mkShell { nativeBuildInputs = [ pkgs.act pkgs.actionlint ]; };
+          default = pkgs.mkShell {
+            nativeBuildInputs = [
+              rust
+              pkgs.python3
+            ];
+          };
+          github-actions = pkgs.mkShell {
+            nativeBuildInputs = [
+              pkgs.act
+              pkgs.actionlint
+              pkgs.pinact
+            ];
+          };
         };
-      });
+      }
+    );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,8 @@
             nativeBuildInputs = [
               rust
               pkgs.python3
+              pkgs.pkg-config
+              pkgs.systemd
             ];
           };
           github-actions = pkgs.mkShell {

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -522,9 +522,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -769,18 +769,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.206"
+version = "1.0.207"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b3e4cd94123dd520a128bcd11e34d9e9e423e7e3e50425cb1b4b1e3549d0284"
+checksum = "5665e14a49a4ea1b91029ba7d3bca9f299e1f7cfa194388ccc20f14743e784f2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.206"
+version = "1.0.207"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabfb6138d2383ea8208cf98ccf69cdfb1aff4088460681d84189aa259762f97"
+checksum = "6aea2634c86b0e8ef2cfdc0c340baede54ec27b1e46febd7f80dffb2aa44a00e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -789,9 +789,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.122"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
+checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
 dependencies = [
  "itoa",
  "memchr",
@@ -873,9 +873,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.73"
+version = "2.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "837a7e8026c6ce912ff01cefbe8cafc2f8010ac49682e2a3d9decc3bce1ecaaf"
+checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -208,15 +208,15 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crossterm"
-version = "0.27.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags 2.6.0",
  "crossterm_winapi",
- "libc",
  "mio",
  "parking_lot",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -331,7 +331,7 @@ dependencies = [
  "serialport",
  "shlex",
  "tempfile",
- "which 5.0.0",
+ "which 6.0.2",
 ]
 
 [[package]]
@@ -366,6 +366,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -438,7 +444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -516,14 +522,15 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
 dependencies = [
+ "hermit-abi",
  "libc",
  "log",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -573,7 +580,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -961,15 +968,14 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "5.0.0"
+version = "6.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bf3ea8596f3a0dd5980b46430f2058dfe2c36a27ccfbb1845d6fbfcd9ba6e14"
+checksum = "3d9c5ed668ee1f17edb3b627225343d210006a90bb1e3745ce1f30b1fb115075"
 dependencies = [
  "either",
  "home",
- "once_cell",
  "rustix",
- "windows-sys 0.48.0",
+ "winsafe",
 ]
 
 [[package]]
@@ -996,20 +1002,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1018,22 +1015,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1042,21 +1024,15 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1066,21 +1042,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1096,21 +1060,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1120,27 +1072,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "zerocopy"

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -55,7 +55,7 @@ RUN mkdir src && \
 WORKDIR /app/flipperzero-rs/tools
 COPY ./tools .
 RUN cargo build --bin=generate-bindings
-RUN find /app/firmware/; cargo run --bin=generate-bindings /app/firmware/build/f7-firmware-D/sdk_headers
+RUN cargo run --bin=generate-bindings /app/firmware/build/f7-firmware-D/sdk_headers
 
 ####################
 FROM scratch

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -66,4 +66,7 @@ WORKDIR /app/flipperzero-rs/crates
 #RUN cargo build --release
 
 ####################
-ENTRYPOINT [ "cat", "sys/src/bindings.rs" ]
+FROM alpine
+COPY --from=builder /app/flipperzero-rs/crates/sys/src/bindings.rs /app/bindings.rs
+WORKDIR /app
+ENTRYPOINT [ "cat", "bindings.rs" ]

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,8 +1,9 @@
+# syntax=docker/dockerfile:1
 FROM --platform=x86_64 debian:bookworm AS firmware-builder
 
 # FIRMWARE_GIT should be a git repo with the firmware source code
-ARG FIRMWARE_GIT=https://github.com/flipperdevices/flipperzero-firmware.git
-ARG BRANCH=0.102.3
+ARG FIRMWARE_GIT="https://github.com/flipperdevices/flipperzero-firmware.git"
+ARG BRANCH="0.102.3"
 
 # Install dependencies
 RUN apt-get update && apt-get install -y \
@@ -13,16 +14,16 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
-
-RUN git clone --branch $BRANCH --recursive $FIRMWARE_GIT firmware
+ADD --keep-git-dir=true "${FIRMWARE_GIT}#${BRANCH}" firmware
 
 WORKDIR /app/firmware
-
 RUN ./fbt
 
 ####################
 # bindgen
 FROM --platform=x86_64 rust:bookworm AS builder
+
+ARG CLANG_URL="https://github.com/llvm/llvm-project/releases/download/llvmorg-17.0.6/clang+llvm-17.0.6-x86_64-linux-gnu-ubuntu-22.04.tar.xz"
 
 # Install dependencies
 RUN apt-get update && apt-get install -y \
@@ -33,11 +34,13 @@ RUN apt-get update && apt-get install -y \
 
 RUN rustup component add rustfmt
 
-WORKDIR /app
+# We don't use debian's libclang. For details see https://github.com/flipperzero-rs/flipperzero/pull/70#discussion_r1199723419
+RUN mkdir --parents /lib/clang
+RUN curl --location "${CLANG_URL}" | tar --extract --xz --directory=/lib/clang --strip-components=1
+ENV LIBCLANG_PATH="/lib/clang/lib"
 
-RUN curl -L https://github.com/llvm/llvm-project/releases/download/llvmorg-17.0.6/clang+llvm-17.0.6-x86_64-linux-gnu-ubuntu-22.04.tar.xz | tar -x --xz
-
-COPY --from=firmware-builder /app/firmware /app/firmware
+COPY --from=firmware-builder /app/firmware/toolchain/ /app/firmware/toolchain/
+COPY --from=firmware-builder /app/firmware/build/f7-firmware-D/sdk_headers/ /app/firmware/build/f7-firmware-D/sdk_headers/
 
 WORKDIR /app/flipperzero-rs/
 
@@ -49,24 +52,13 @@ RUN mkdir src && \
     cargo build
 
 # Now copy the rest of the files
-WORKDIR /app/flipperzero-rs/
-COPY . .
-
 WORKDIR /app/flipperzero-rs/tools
-# We don't use debian's libclang. For details see https://github.com/flipperzero-rs/flipperzero/pull/70#discussion_r1199723419
-RUN env LIBCLANG_PATH=/app/clang+llvm-17.0.6-x86_64-linux-gnu-ubuntu-22.04/lib \
-    cargo run --bin generate-bindings /app/firmware/build/f7-firmware-D/sdk_headers/
-
-WORKDIR /app/flipperzero-rs
-RUN cp ./tools/bindings.rs ./crates/sys/src
-
-# test it builds
-# This step is skipped until the SDK is stabilized (i.e. version `1` is published)
-#WORKDIR /app/flipperzero-rs/crates
-#RUN cargo build --release
+COPY ./tools .
+RUN cargo build --bin=generate-bindings
+RUN find /app/firmware/; cargo run --bin=generate-bindings /app/firmware/build/f7-firmware-D/sdk_headers
 
 ####################
 FROM scratch
-COPY --from=builder /app/flipperzero-rs/crates/sys/src/bindings.rs /
+COPY --from=builder /app/flipperzero-rs/tools/bindings.rs /
 # Formal entrypoint to simplify the usage of `docker container create`
-ENTRYPOINT /
+ENTRYPOINT ["/"]

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -58,15 +58,13 @@ RUN env LIBCLANG_PATH=/app/clang+llvm-17.0.6-x86_64-linux-gnu-ubuntu-22.04/lib \
     cargo run --bin generate-bindings /app/firmware/build/f7-firmware-D/sdk_headers/
 RUN cp bindings.rs ../crates/sys/src
 
-WORKDIR /app/flipperzero-rs/crates
-
 # test it builds
 # This step is skipped until the SDK is stabilized (i.e. version `1` is published)
 #WORKDIR /app/flipperzero-rs/crates
 #RUN cargo build --release
 
 ####################
-FROM alpine
-COPY --from=builder /app/flipperzero-rs/crates/sys/src/bindings.rs /app/bindings.rs
-WORKDIR /app
-ENTRYPOINT [ "cat", "bindings.rs" ]
+FROM scratch
+COPY --from=builder /app/flipperzero-rs/crates/sys/src/bindings.rs /bindings.rs
+# Formal entrypoint to simplify the usage of `docker container create`
+ENTRYPOINT /

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -67,6 +67,6 @@ RUN cp ./tools/bindings.rs ./crates/sys/src
 
 ####################
 FROM scratch
-COPY --from=builder /app/flipperzero-rs/crates/sys/src/bindings.rs /bindings.rs
+COPY --from=builder /app/flipperzero-rs/crates/sys/src/bindings.rs /
 # Formal entrypoint to simplify the usage of `docker container create`
 ENTRYPOINT /

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -56,7 +56,9 @@ WORKDIR /app/flipperzero-rs/tools
 # We don't use debian's libclang. For details see https://github.com/flipperzero-rs/flipperzero/pull/70#discussion_r1199723419
 RUN env LIBCLANG_PATH=/app/clang+llvm-17.0.6-x86_64-linux-gnu-ubuntu-22.04/lib \
     cargo run --bin generate-bindings /app/firmware/build/f7-firmware-D/sdk_headers/
-RUN cp bindings.rs ../crates/sys/src
+
+WORKDIR /app/flipperzero-rs
+RUN cp ./tools/bindings.rs ./crates/sys/src
 
 # test it builds
 # This step is skipped until the SDK is stabilized (i.e. version `1` is published)


### PR DESCRIPTION
# Description

This adds a new manual GitHub Action task capable of updating SDK version and creating a PR with the change.

This also pins dependency versions using `pinact` (which is supported by Dependabot) to ensure security.

# Notes

This is built on top of #151