### PR TITLE
Add Safe Abstractions for `FuriStreamBuffer`

### DIFF
--- a/crates/flipperzero/Cargo.toml
+++ b/crates/flipperzero/Cargo.toml
@@ -68,6 +68,12 @@ crc32fast = { version = "1", default-features = false }
 ## ```
 alloc = []
 
+## Allows using the safe abstraction for stream buffers.
+##
+## This requires the `alloc` feature and therefore requires everything it 
+## requires.
+stream-buffer = ["alloc"]
+
 [[test]]
 name = "dolphin"
 harness = false

--- a/crates/flipperzero/Cargo.toml
+++ b/crates/flipperzero/Cargo.toml
@@ -81,5 +81,9 @@ name = "dialog"
 required-features = ["alloc"]
 
 [[example]]
+name = "stream_buffer"
+required-features = ["alloc"]
+
+[[example]]
 name = "threads"
 required-features = ["alloc"]

--- a/crates/flipperzero/Cargo.toml
+++ b/crates/flipperzero/Cargo.toml
@@ -68,12 +68,6 @@ crc32fast = { version = "1", default-features = false }
 ## ```
 alloc = []
 
-## Allows using the safe abstraction for stream buffers.
-##
-## This requires the `alloc` feature and therefore requires everything it 
-## requires.
-stream-buffer = ["alloc"]
-
 [[test]]
 name = "dolphin"
 harness = false

--- a/crates/flipperzero/examples/stream_buffer.rs
+++ b/crates/flipperzero/examples/stream_buffer.rs
@@ -1,0 +1,33 @@
+//! Example showcasing the use of a stream buffer on multiple threads.
+
+#![no_main]
+#![no_std]
+
+// Required for panic handler
+extern crate flipperzero_rt;
+
+// Required for allocator
+extern crate flipperzero_alloc;
+
+extern crate alloc;
+
+use alloc::borrow::ToOwned;
+use core::{ffi::CStr, num::NonZeroUsize};
+use core::time::Duration;
+
+use flipperzero::{furi::{self, thread}, println};
+use flipperzero_rt::{entry, manifest};
+
+// Define the FAP Manifest for this application
+manifest!(name = "Stream buffer example");
+
+// Define the entry function
+entry!(main);
+
+// Entry point
+fn main(_args: Option<&CStr>) -> i32 {
+    let size = NonZeroUsize::new(1024).unwrap();
+    let trigger_level = 16;
+    let (tx, rx) = furi::stream_buffer::stream_buffer(size, trigger_level);
+    0
+}

--- a/crates/flipperzero/examples/stream_buffer.rs
+++ b/crates/flipperzero/examples/stream_buffer.rs
@@ -11,11 +11,9 @@ extern crate flipperzero_alloc;
 
 extern crate alloc;
 
-use alloc::borrow::ToOwned;
-use core::{ffi::CStr, num::NonZeroUsize};
-use core::time::Duration;
+use core::{ffi::CStr, num::NonZeroUsize, time::Duration};
 
-use flipperzero::{furi::{self, thread}, println};
+use flipperzero::{furi, println};
 use flipperzero_rt::{entry, manifest};
 
 // Define the FAP Manifest for this application
@@ -26,8 +24,62 @@ entry!(main);
 
 // Entry point
 fn main(_args: Option<&CStr>) -> i32 {
+    // Create a stream buffer pair
     let size = NonZeroUsize::new(1024).unwrap();
     let trigger_level = 16;
     let (tx, rx) = furi::stream_buffer::stream_buffer(size, trigger_level);
+
+    // Stream buffer is empty
+    assert_eq!(tx.spaces_available(), size.into());
+    assert_eq!(rx.spaces_available(), size.into());
+    assert_eq!(tx.bytes_available(), 0);
+    assert_eq!(rx.bytes_available(), 0);
+
+    // Sending 4 bytes immediately
+    assert_eq!(tx.send(&[1, 2, 3, 4]), 4);
+    assert_eq!(tx.bytes_available(), 4);
+
+    // Receive bytes
+    let mut recv_buf = [0; 32];
+    assert_eq!(rx.recv(&mut recv_buf), 4);
+    assert_eq!(recv_buf[0..4], [1, 2, 3, 4]);
+
+    // Move sender to another thread
+    let tx_thread = furi::thread::spawn(move || {
+        // Wait 2 seconds before we send some bytes
+        furi::thread::sleep(Duration::from_secs(2));
+        assert_eq!(tx.send(&[5; 20]), 20);
+
+        // Send some bytes in a loop to see how the receiver handles them
+        for i in 4..20 {
+            furi::thread::sleep(Duration::from_millis(200));
+            tx.send(&[i as u8; 3]);
+        }
+
+        0
+    });
+
+    // Move receiver to another thread
+    let rx_thread = furi::thread::spawn(move || {
+        let mut buf = [0; 32];
+
+        // The sender waits 2 seconds, so we don't block and get no bytes
+        assert_eq!(rx.recv(&mut buf), 0);
+
+        // The sender sends 20 bytes after two seconds, that is more than the trigger, so we continue
+        assert_eq!(rx.recv_blocking(&mut buf), 20);
+
+        // Try to receive bytes as long as the sender is alive
+        while rx.is_sender_alive() {
+            let n = rx.recv_with_timeout(&mut buf, Duration::from_secs(2));
+            println!("got {} bytes: {:?}", n, buf[0..n]);
+        }
+
+        0
+    });
+
+    tx_thread.join();
+    rx_thread.join();
+
     0
 }

--- a/crates/flipperzero/src/furi/mod.rs
+++ b/crates/flipperzero/src/furi/mod.rs
@@ -4,6 +4,8 @@ pub mod io;
 pub mod log;
 pub mod message_queue;
 pub mod rng;
+#[cfg(feature = "alloc")]
+pub mod stream_buffer;
 pub mod string;
 pub mod sync;
 pub mod thread;

--- a/crates/flipperzero/src/furi/mod.rs
+++ b/crates/flipperzero/src/furi/mod.rs
@@ -4,7 +4,6 @@ pub mod io;
 pub mod log;
 pub mod message_queue;
 pub mod rng;
-#[cfg(feature = "stream-buffer")]
 pub mod stream_buffer;
 pub mod string;
 pub mod sync;

--- a/crates/flipperzero/src/furi/mod.rs
+++ b/crates/flipperzero/src/furi/mod.rs
@@ -4,7 +4,7 @@ pub mod io;
 pub mod log;
 pub mod message_queue;
 pub mod rng;
-#[cfg(feature = "alloc")]
+#[cfg(feature = "stream-buffer")]
 pub mod stream_buffer;
 pub mod string;
 pub mod sync;

--- a/crates/flipperzero/src/furi/stream_buffer.rs
+++ b/crates/flipperzero/src/furi/stream_buffer.rs
@@ -195,7 +195,8 @@ impl StreamBuffer {
     pub fn reset(&self) -> furi::Result<()> {
         let status = unsafe { sys::furi_stream_buffer_reset(self.0.as_ptr()) };
         let status = Status(status);
-        status.err_or(())
+        let _ = status.into_result()?;
+        Ok(())
     }
 }
 

--- a/crates/flipperzero/src/furi/stream_buffer.rs
+++ b/crates/flipperzero/src/furi/stream_buffer.rs
@@ -51,7 +51,7 @@ unsafe impl Send for StreamBuffer {}
 // SAFETY:
 // The furi api only requires users to ensure that only one writer and one reader exists at the same
 // time, they may be moved between threads.
-// Using this data structure between threads remotely is therefore fine.
+// Using this data structure between threads remotely is therefore safe.
 // The safety guarantee for sending and receiving data is therefore shifted to the send and receive
 // methods.
 unsafe impl Sync for StreamBuffer {}

--- a/crates/flipperzero/src/furi/stream_buffer.rs
+++ b/crates/flipperzero/src/furi/stream_buffer.rs
@@ -1,0 +1,414 @@
+use core::{fmt::Debug, num::NonZeroUsize, ptr::NonNull};
+
+use alloc::sync::Arc;
+
+use flipperzero_sys::{self as sys, furi::Status};
+
+/// Basic Result which only indicates whether something succeeded or not.
+type EmptyResult = Result<(), ()>;
+
+// https://github.com/flipperdevices/flipperzero-firmware/blob/b723d463afccf628712475e11a3d4579f0331f5c/furi/core/base.h#L13
+const FURI_WAIT_FOREVER: u32 = 0xFFFFFFFF;
+
+/// Furi stream buffer primitive.
+///
+/// Stream buffers are used to send a continous stream of data from one task or interrupt to another.
+/// Their implementation is light weight, making them particularly suited for interrupt to task and
+/// core to core communication scenarios.
+///
+/// # Note
+///
+/// Stream buffer implementation assumes there is only one task or interrupt that will write to the
+/// buffer (the writer), and only one task or interrupt that will read from the buffer (the reader).
+///
+/// # Visibility and Safety
+///
+/// Since the stream buffer's implementation assumes that only one task or interrupt will write to
+/// the buffer and only one task or interrupt will read from the buffer, we have to ensure this
+/// behavior in the type system to make sound safe abstractions.
+///
+/// To achieve this, the `StreamBuffer` itself is not public.
+/// To send and receive data, we use the [`Sender`] and [`Receiver`], both of them own a reference
+/// to the `StreamBuffer` to perform any actions on it.
+/// Both are not [`Clone`], making sure we don't have any more senders and receivers on the same
+/// stream buffer.
+/// Also both are [`Send`] to send them to other threads but not [`Sync`] to ensure that only one
+/// thread can use them at any time respectively.
+#[derive(Debug)]
+struct StreamBuffer(NonNull<sys::FuriStreamBuffer>);
+
+/// Direct implementation of the `furi_stream_buffer` api.
+///
+/// The [`Sender`] and [`Receiver`] have some more sugar to use that api.
+impl StreamBuffer {
+    /// Create a new instance of a `StreamBuffer`.
+    ///
+    /// The `furi_stream_buffer_alloc` function checks that the size is not 0, to always fulfill
+    /// this requirement the `size` is a `NonZeroUsize`.
+    ///
+    /// Further user reference is explained at the [`stream_buffer`] function.
+    fn new(size: NonZeroUsize, trigger_level: usize) -> Self {
+        unsafe {
+            Self(NonNull::new_unchecked(sys::furi_stream_buffer_alloc(
+                size.into(),
+                trigger_level,
+            )))
+        }
+    }
+
+    fn set_trigger_level(&self, trigger_level: usize) -> EmptyResult {
+        let updated = unsafe { sys::furi_stream_set_trigger_level(self.0.as_ptr(), trigger_level) };
+        match updated {
+            true => Ok(()),
+            false => Err(()),
+        }
+    }
+
+    fn send(&self, data: &[u8], timeout: u32) -> usize {
+        unsafe {
+            sys::furi_stream_buffer_send(self.0.as_ptr(), data.as_ptr().cast(), data.len(), timeout)
+        }
+    }
+
+    fn receive(&self, data: &mut [u8], timeout: u32) -> usize {
+        unsafe {
+            sys::furi_stream_buffer_receive(
+                self.0.as_ptr(),
+                data.as_mut_ptr().cast(),
+                data.len(),
+                timeout,
+            )
+        }
+    }
+
+    fn bytes_available(&self) -> usize {
+        unsafe { sys::furi_stream_buffer_bytes_available(self.0.as_ptr()) }
+    }
+
+    fn spaces_available(&self) -> usize {
+        unsafe { sys::furi_stream_buffer_bytes_available(self.0.as_ptr()) }
+    }
+
+    fn is_full(&self) -> bool {
+        unsafe { sys::furi_stream_buffer_is_full(self.0.as_ptr()) }
+    }
+
+    fn is_empty(&self) -> bool {
+        unsafe { sys::furi_stream_buffer_is_empty(self.0.as_ptr()) }
+    }
+
+    fn reset(&self) -> EmptyResult {
+        let status = unsafe { sys::furi_stream_buffer_reset(self.0.as_ptr()) };
+        let status = Status(status);
+        match status {
+            Status::OK => Ok(()),
+            Status::ERR => Err(()),
+            _ => unreachable!("furi_stream_buffer_reset only returns Ok or Error"),
+        }
+    }
+}
+
+impl Drop for StreamBuffer {
+    fn drop(&mut self) {
+        // SAFETY:
+        // Since we keep an Arc in both, the sender and receiver, we know we only drop when both of
+        // them are dropped too.
+        unsafe {
+            sys::furi_stream_buffer_free(self.0.as_ptr());
+        }
+    }
+}
+
+/// Sender side of a furi stream buffer.
+/// 
+/// An instance can be obtained using the [`stream_buffer`] function.
+/// 
+/// This struct allows sending data through the stream buffer, checking its state, or resetting it. 
+/// Use the [`is_receiver_alive`](Self::is_receiver_alive) method to verify if the associated 
+/// [`Receiver`] is still alive, helping to avoid sending data that will not be read.
+pub struct Sender {
+    buffer_ref: Arc<StreamBuffer>,
+}
+
+impl Debug for Sender {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // the receiver_alive field is not real but a nice debug information
+        f.debug_struct("Sender")
+            .field("buffer_ref", &self.buffer_ref)
+            .field("receiver_alive", &self.is_receiver_alive())
+            .finish()
+    }
+}
+
+unsafe impl Send for Sender {}
+
+/// Sends data using the `Sender`.
+/// 
+/// Data is sent only when the amount of bytes reaches the trigger level in the underlying stream 
+/// buffer, which wakes up the listening [`Receiver`] if applicable.
+/// 
+/// Returns the number of bytes that were successfully sent.
+/// 
+/// # Interrupt Routines
+/// 
+/// When used in an interrupt routine, the timeout will be ignored.
+impl Sender {
+    /// Sends bytes without blocking.
+    /// 
+    /// Attempts to send the specified bytes immediately. 
+    /// If the underlying stream buffer does not have enough free space, it sends only the bytes 
+    /// that fit and returns immediately.
+    pub fn send(&self, data: &[u8]) -> usize {
+        self.buffer_ref.send(data, 0)
+    }
+
+    /// Sends bytes in a blocking manner.
+    /// 
+    /// Blocks until all bytes are sent. 
+    /// 
+    /// # Interrupt Routines
+    /// 
+    /// In an interrupt routine, this method behaves like [`send`](Self::send).
+    pub fn send_blocking(&self, data: &[u8]) -> usize {
+        self.buffer_ref.send(data, FURI_WAIT_FOREVER)
+    }
+
+    /// Sends bytes with a timeout.
+    /// 
+    /// Attempts to send as many bytes as possible within the specified timeout duration. 
+    /// It may wait until the timeout is reached if necessary, but it returns immediately once all 
+    /// bytes are sent or the timeout expires.
+    /// 
+    /// # Interrupt Routines
+    /// 
+    /// In an interrupt routine, this method behaves like [`send`](Self::send).
+    pub fn send_with_timeout(&self, data: &[u8], timeout: core::time::Duration) -> usize {
+        let timeout = sys::furi::duration_to_ticks(timeout);
+        self.buffer_ref.send(data, timeout)
+    }
+}
+
+/// Check or modify the underlying furi stream buffer.
+impl Sender {
+    /// Set the trigger level for the underlying stream buffer.
+    /// 
+    /// The trigger level is the number of bytes that must be present in the stream buffer before 
+    /// any blocked tasks waiting for data can proceed. 
+    /// 
+    /// If the specified trigger level exceeds the buffer's length, an [`Err`] is returned.
+    pub fn set_trigger_level(&mut self, trigger_level: usize) -> EmptyResult {
+        self.buffer_ref.set_trigger_level(trigger_level)
+    }
+
+    /// Get the number of bytes currently available in the underlying stream buffer.
+    pub fn bytes_available(&self) -> usize {
+        self.buffer_ref.bytes_available()
+    }
+
+    /// Get the number of bytes that can still fit in the underlying stream buffer.
+    pub fn spaces_available(&self) -> usize {
+        self.buffer_ref.spaces_available()
+    }
+
+    /// Check if the underlying stream buffer is full.
+    pub fn is_full(&self) -> bool {
+        self.buffer_ref.is_full()
+    }
+
+    /// Check if the underlying stream buffer is empty.
+    pub fn is_empty(&self) -> bool {
+        self.buffer_ref.is_empty()
+    }
+
+    /// Attempt to reset the underlying stream buffer.
+    /// 
+    /// This will clear the buffer, discarding any data it contains and returning it to its initial 
+    /// empty state. 
+    /// The reset can only occur if there are no tasks blocked waiting to send to or receive from 
+    /// the stream buffer; attempting to reset during this time will result in an [`Err`].
+    pub fn reset(&mut self) -> EmptyResult {
+        self.buffer_ref.reset()
+    }
+}
+
+
+/// Pure additional methods to work with the `Sender` and [`Receiver`].
+impl Sender {
+    /// Check if the associated receiver is still alive.
+    /// 
+    /// This method helps prevent unnecessary data transmission when the [`Receiver`] is no longer 
+    /// available.
+    pub fn is_receiver_alive(&self) -> bool {
+        // SAFETY:
+        // Since both Receiver and Sender are not Clone, the only Arcs are those created by the
+        // stream_buffer function.
+        // If the strong count of the Arc referencing the buffer is 2, it indicates that
+        // the Receiver and the related Sender are still alive.
+        Arc::strong_count(&self.buffer_ref) == 2
+    }
+}
+
+/// Receiver side of a furi stream buffer.
+/// 
+/// An instance can be obtained using the [`stream_buffer`] function.
+/// 
+/// This struct allows receiving data through the stream buffer, checking its state, or resetting it.
+/// Use the [`is_sender_alive`](Self::is_sender_alive) method to verify if the associated
+/// [`Sender`] is still alive, helping to avoid trying to receive data that will never be sent.
+pub struct Receiver {
+    buffer_ref: Arc<StreamBuffer>,
+}
+
+impl Debug for Receiver {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // the sender_alive field is not real but a nice debug information
+        f.debug_struct("Receiver")
+            .field("buffer_ref", &self.buffer_ref)
+            .field("sender_alive", &self.is_sender_alive())
+            .finish()
+    }
+}
+
+unsafe impl Send for Receiver {}
+
+/// Receive data using the `Receiver`.
+/// 
+/// Data is received only when the amount of bytes reaches the trigger level in the underlying 
+/// stream buffer.
+/// 
+/// Returns the number of bytes that were successfully received.
+/// 
+/// # Interrupt Routines
+/// 
+/// When used in an interrupt routine, the timeout will be ignored.
+impl Receiver {
+    /// Receive bytes without blocking.
+    /// 
+    /// Attempts to receive bytes immediately. 
+    /// If the underlying stream buffer is empty, it returns the number of bytes that were 
+    /// successfully received.
+    pub fn recv(&self, data: &mut [u8]) -> usize {
+        self.buffer_ref.receive(data, 0)
+    }
+
+    /// Receive bytes in a blocking manner.
+    /// 
+    /// Blocks until all requested bytes are received. 
+    /// If the stream buffer is empty, this method will wait until data becomes available.
+    /// 
+    /// # Interrupt Routines
+    /// 
+    /// In an interrupt routine, this method behaves like [`recv`](Self::recv).
+    pub fn recv_blocking(&self, data: &mut [u8]) -> usize {
+        self.buffer_ref.receive(data, FURI_WAIT_FOREVER)
+    }
+
+    /// Receive bytes with a timeout.
+    /// 
+    /// Attempts to receive as many bytes as possible within the specified timeout duration. 
+    /// If all bytes are received before the timeout expires, it returns immediately; otherwise, 
+    /// it returns the number of bytes received when the timeout occurs.
+    /// 
+    /// # Interrupt Routines
+    /// 
+    /// In an interrupt routine, this method behaves like [`recv`](Self::recv).
+    pub fn recv_with_timeout(&self, data: &mut [u8], timeout: core::time::Duration) -> usize {
+        let timeout = sys::furi::duration_to_ticks(timeout);
+        self.buffer_ref.receive(data, timeout)
+    }
+}
+
+/// Check or modify the underlying furi stream buffer.
+impl Receiver {
+    /// Set the trigger level for the underlying stream buffer.
+    /// 
+    /// The trigger level is the number of bytes that must be present in the stream buffer 
+    /// before blocked tasks waiting to receive data can proceed. 
+    /// If the specified trigger level exceeds the buffer's length, an [`Err`] is returned.
+    pub fn set_trigger_level(&mut self, trigger_level: usize) -> EmptyResult {
+        self.buffer_ref.set_trigger_level(trigger_level)
+    }
+
+    /// Get the number of bytes currently available in the underlying stream buffer.
+    pub fn bytes_available(&self) -> usize {
+        self.buffer_ref.bytes_available()
+    }
+
+    /// Get the number of bytes that can still fit in the underlying stream buffer.
+    pub fn spaces_available(&self) -> usize {
+        self.buffer_ref.spaces_available()
+    }
+
+    /// Check if the underlying stream buffer is full.
+    pub fn is_full(&self) -> bool {
+        self.buffer_ref.is_full()
+    }
+
+    /// Check if the underlying stream buffer is empty.
+    pub fn is_empty(&self) -> bool {
+        self.buffer_ref.is_empty()
+    }
+
+    /// Attempt to reset the underlying stream buffer.
+    /// 
+    /// This will clear the buffer, discarding any data it contains and returning it to its 
+    /// initial empty state. 
+    /// The reset can only occur if there are no tasks blocked waiting to send to or receive from 
+    /// the stream buffer; attempting to reset during this time will result in an [`Err`].
+    pub fn reset(&mut self) -> EmptyResult {
+        self.buffer_ref.reset()
+    }
+}
+
+/// Pure additional methods to work with the [`Sender`] and `Receiver`.
+impl Receiver {
+    /// Check if the associated sender is still alive.
+    /// 
+    /// This method helps prevent unnecessary data reception when the sender is no longer available.
+    pub fn is_sender_alive(&self) -> bool {
+        // SAFETY:
+        // Since both Receiver and Sender are not Clone, the only Arcs are those created by the
+        // stream_buffer function.
+        // If the strong count of the Arc referencing the buffer is 2, it indicates that
+        // the Receiver and the related Sender are still alive.
+        Arc::strong_count(&self.buffer_ref) == 2
+    }
+}
+
+/// Create a [`Sender`]/[`Receiver`] pair for a furi stream buffer.
+/// 
+/// This function initializes a furi stream buffer and provides access through the returned 
+/// [`Sender`] and [`Receiver`] instances.
+/// 
+/// The `size` parameter must be a non-zero value, as the stream buffer requires a valid size 
+/// to allocate memory. 
+/// The `furi_stream_buffer_alloc` function enforces this constraint by rejecting zero sizes.
+/// 
+/// The `trigger_level` defines the number of bytes that must be present in the stream buffer 
+/// before any blocked tasks waiting for data can proceed. 
+// TODO: investigate what happens when we set the trigger level to high here
+/// 
+/// The Furi stream buffer is designed for single-task or single-interrupt access for both 
+/// writing and reading operations. 
+/// To enforce this, it splits the buffer into two parts, similar to the `mpsc::Sender` and 
+/// `mpsc::Receiver` from the standard library. 
+/// Both the sender and receiver maintain an owned reference to the stream buffer, ensuring it 
+/// remains alive as long as either one exists. 
+/// They can verify if their corresponding pair is still alive using [`Sender::is_receiver_alive`] 
+/// and [`Receiver::is_sender_alive`] respectively.
+/// 
+/// Additionally, both the sender and receiver implement [`Send`] to allow transfer between 
+/// threads. 
+/// However, they explicitly do not implement [`Sync`] or [`Clone`] to guarantee that only one 
+/// writer and one reader can exist at any given time per task.
+pub fn stream_buffer(size: NonZeroUsize, trigger_level: usize) -> (Sender, Receiver) {
+    let stream_buffer = StreamBuffer::new(size, trigger_level);
+    let stream_buffer = Arc::new(stream_buffer);
+    let sender = Sender {
+        buffer_ref: stream_buffer.clone(),
+    };
+    let receiver = Receiver {
+        buffer_ref: stream_buffer.clone(),
+    };
+    (sender, receiver)
+}

--- a/crates/flipperzero/src/furi/stream_buffer.rs
+++ b/crates/flipperzero/src/furi/stream_buffer.rs
@@ -1,3 +1,5 @@
+//! Furi stream buffer primitive.
+
 use core::{
     cell::Cell, ffi::c_void, fmt::Debug, marker::PhantomData, num::NonZeroUsize, ptr::NonNull,
 };

--- a/crates/flipperzero/src/furi/stream_buffer.rs
+++ b/crates/flipperzero/src/furi/stream_buffer.rs
@@ -86,7 +86,7 @@ impl StreamBuffer {
     }
 
     fn spaces_available(&self) -> usize {
-        unsafe { sys::furi_stream_buffer_bytes_available(self.0.as_ptr()) }
+        unsafe { sys::furi_stream_buffer_spaces_available(self.0.as_ptr()) }
     }
 
     fn is_full(&self) -> bool {

--- a/crates/flipperzero/src/furi/stream_buffer.rs
+++ b/crates/flipperzero/src/furi/stream_buffer.rs
@@ -327,11 +327,6 @@ mod stream {
 
     /// Pure additional methods to work with the `Sender` and [`Receiver`].
     impl Sender {
-        /// Get a reference to the underlying [`StreamBuffer`].
-        pub fn as_stream_buffer(&self) -> &StreamBuffer {
-            &self.buffer_ref
-        }
-
         /// Check if the associated receiver is still alive.
         ///
         /// This method helps prevent unnecessary data transmission when the [`Receiver`] is no
@@ -344,6 +339,20 @@ mod stream {
             // the Receiver and the related Sender are still alive.
             Arc::strong_count(&self.buffer_ref) == 2
         }
+
+        /// Get a reference to the underlying [`StreamBuffer`].
+        pub fn as_stream_buffer(&self) -> &StreamBuffer {
+            &self.buffer_ref
+        }
+
+        /// Try to get the underlying stream buffer.
+        /// 
+        /// This method tries to get underlying stream buffer, which is only possible if the 
+        /// [`Receiver`] is already dropped.
+        /// If the `Receiver` is still alive, this will return [`None`].
+        pub fn into_stream_buffer(self) -> Option<StreamBuffer> {
+            Arc::into_inner(self.buffer_ref)
+        } 
     }
 
     /// Receiver side of a furi stream buffer.
@@ -432,11 +441,6 @@ mod stream {
 
     /// Pure additional methods to work with the [`Sender`] and `Receiver`.
     impl Receiver {
-        /// Get a reference to the underlying [`StreamBuffer`].
-        pub fn as_stream_buffer(&self) -> &StreamBuffer {
-            &self.buffer_ref
-        }
-
         /// Check if the associated sender is still alive.
         ///
         /// This method helps prevent unnecessary data reception when the sender is no longer
@@ -449,5 +453,19 @@ mod stream {
             // the Receiver and the related Sender are still alive.
             Arc::strong_count(&self.buffer_ref) == 2
         }
+
+        /// Get a reference to the underlying [`StreamBuffer`].
+        pub fn as_stream_buffer(&self) -> &StreamBuffer {
+            &self.buffer_ref
+        }
+
+        /// Try to get the underlying stream buffer.
+        /// 
+        /// This method tries to get underlying stream buffer, which is only possible if the 
+        /// [`Sender`] is already dropped.
+        /// If the `Sender` is still alive, this will return [`None`].
+        pub fn into_stream_buffer(self) -> Option<StreamBuffer> {
+            Arc::into_inner(self.buffer_ref)
+        } 
     }
 }

--- a/crates/flipperzero/src/furi/stream_buffer.rs
+++ b/crates/flipperzero/src/furi/stream_buffer.rs
@@ -280,7 +280,7 @@ unsafe impl Send for Receiver {}
 impl Receiver {
     /// Receive bytes without blocking.
     ///
-    /// Tries to receive bytes immediately. It will either receive all available bytes or fill the 
+    /// Tries to receive bytes immediately. It will either receive all available bytes or fill the
     /// buffer, whichever happens first.
     /// Returns the number of bytes successfully received.
     pub fn recv(&self, data: &mut [u8]) -> usize {
@@ -290,10 +290,10 @@ impl Receiver {
     /// Receive bytes, blocking if necessary.
     ///
     /// Waits until the buffer is filled or the [trigger level](Self::set_trigger_level) is reached.
-    /// More bytes than the trigger level may be received if a large enough chunk arrives at once, 
+    /// More bytes than the trigger level may be received if a large enough chunk arrives at once,
     /// though it may still be less than the full buffer.
     /// Returns the number of bytes successfully received.
-    /// 
+    ///
     /// # Interrupt Routines
     ///
     /// If called in an interrupt routine, this behaves like [`recv`](Self::recv).
@@ -303,7 +303,7 @@ impl Receiver {
 
     /// Receive bytes with a timeout.
     ///
-    /// Waits until the buffer is filled, the [trigger level](Self::set_trigger_level) is reached, 
+    /// Waits until the buffer is filled, the [trigger level](Self::set_trigger_level) is reached,
     /// or the timeout expires, whichever happens first.
     /// Returns the number of bytes successfully received.
     ///

--- a/crates/flipperzero/src/furi/stream_buffer.rs
+++ b/crates/flipperzero/src/furi/stream_buffer.rs
@@ -115,7 +115,7 @@ impl StreamBuffer {
     #[cfg_attr(feature = "alloc", doc = "[`Sender`],")]
     /// available using the `alloc` feature.
     ///
-    /// # Interrupt Routine
+    /// # Interrupt Routines
     ///
     /// Inside of an interrupt routine the `timeout` is ignored.
     pub unsafe fn send(&self, data: &[u8], timeout: furi::time::Duration) -> usize {
@@ -148,7 +148,7 @@ impl StreamBuffer {
     #[cfg_attr(feature = "alloc", doc = "[`Receiver`],")]
     /// available using the `alloc` feature.
     ///
-    /// # Interrupt Routine
+    /// # Interrupt Routines
     ///
     /// Inside of an interrupt routine the `timeout` is ignored.
     pub unsafe fn receive(&self, data: &mut [u8], timeout: furi::time::Duration) -> usize {

--- a/crates/flipperzero/src/furi/time.rs
+++ b/crates/flipperzero/src/furi/time.rs
@@ -211,6 +211,13 @@ impl Duration {
     /// practice on stock firmware.
     pub const MAX: Duration = Duration(MAX_DURATION_TICKS);
 
+    /// Wait forever.
+    ///
+    /// This constant may be used for all cases where a operation should block indefinitely.
+    /// The value is originally defined in the
+    /// [flipper zero firmware](https://github.com/flipperdevices/flipperzero-firmware/blob/b723d463afccf628712475e11a3d4579f0331f5c/furi/core/base.h#L13).
+    pub const WAIT_FOREVER: Duration = Duration(0xFFFFFFFF);
+
     /// Creates a new `Duration` from the specified number of whole seconds.
     ///
     /// # Panics


### PR DESCRIPTION
Hey 👋🏻,
In this PR, I added some safe abstractions for the `FuriStreamBuffer`.

While working on it, I came across this note in the stream buffer implementation:
```
 * ***NOTE***: Stream buffer implementation assumes there is only one task or
 * interrupt that will write to the buffer (the writer), and only one task or
 * interrupt that will read from the buffer (the reader).
```

So, I figured, why not enforce this constraint in the type system? The result is a split into a sender and receiver, similar to the `mpsc` channel in the standard library. They implement `Send`, so they can be moved between threads, but not `Clone` or `Sync`, making sure we only have one of each in a pair. Unfortunately, I had to use `Arc` to give ownership to both sides, which means this requires `alloc`. Other than that, I’m happy with how the API turned out.

I also added an example where data is sent between different threads.