### PR TITLE
Fix `flipperzero::furi::time::Duration::MAX`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - `flipperzero::dialogs::DialogFileBrowserOptions` now uses native initialization function.
+- `flipperzero::time::Duration::MAX` is now the maximum duration representable.
 
 ### Removed
 


### PR DESCRIPTION
Surprisingly, `Duration::MAX` was not the maximum possible duration.

`Duration::MAX` must be able to *contain* the delta between any two `Inteval` values, but not every `Duration` can be used with `Interval` (if `Duration > u32::MAX / 2` then we wouldn't be able to tell if the `Instant` was in the past or the future).