### PR TITLE
Change `Status::err_or_else` to use `Fn(i32) -> T`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `flipperzero::dialogs::DialogFileBrowserOptions` now uses native initialization function.
 - `flipperzero::time::Duration::MAX` is now the maximum duration representable.
+- `sys::furi::Status::err_or_else` now takes a `Fn(i32) -> T` closure.
 
 ### Removed
 

--- a/crates/flipperzero/src/furi/kernel.rs
+++ b/crates/flipperzero/src/furi/kernel.rs
@@ -49,7 +49,7 @@ impl From<LockState> for i32 {
 pub fn lock() -> furi::Result<LockState> {
     let status = sys::furi::Status::from(unsafe { sys::furi_kernel_lock() });
 
-    status.err_or_else(|status| status.0.into())
+    status.err_or_else(LockState::from)
 }
 
 /// Unlock kernel, resume process scheduling.
@@ -60,7 +60,7 @@ pub fn lock() -> furi::Result<LockState> {
 pub fn unlock() -> furi::Result<LockState> {
     let status = sys::furi::Status::from(unsafe { sys::furi_kernel_unlock() });
 
-    status.err_or_else(|status| status.0.into())
+    status.err_or_else(LockState::from)
 }
 
 /// Restore kernel lock state.
@@ -71,7 +71,7 @@ pub fn unlock() -> furi::Result<LockState> {
 pub fn restore_lock(state: LockState) -> furi::Result<LockState> {
     let status = sys::furi::Status::from(unsafe { sys::furi_kernel_restore_lock(state.into()) });
 
-    status.err_or_else(|status| status.0.into())
+    status.err_or_else(LockState::from)
 }
 
 /// Return kernel tick frequency in hertz.

--- a/crates/sys/src/furi.rs
+++ b/crates/sys/src/furi.rs
@@ -60,11 +60,11 @@ impl Status {
     }
 
     /// Returns `Err(Status)` if [`Status`] is an error, otherwise `Ok(or_else(Status))`.
-    pub fn err_or_else<T>(self, or_else: impl Fn(Self) -> T) -> Result<T, Self> {
+    pub fn err_or_else<T>(self, or_else: impl Fn(i32) -> T) -> Result<T, Self> {
         if self.is_err() {
             Err(self)
         } else {
-            Ok(or_else(self))
+            Ok(or_else(self.0))
         }
     }
 }


### PR DESCRIPTION
Rather than a closure that takes a `Status`, take the status code. This allows easier chaining of types (e.g. `X::from`).

Follow-up from #180.