### PR TITLE
chore: don't use legacy numeric constants

### DIFF
--- a/crates/flipperzero/src/furi/thread.rs
+++ b/crates/flipperzero/src/furi/thread.rs
@@ -1,5 +1,6 @@
 //! Furi Thread API.
 
+use core::time;
 #[cfg(feature = "alloc")]
 use core::{
     ffi::{c_void, CStr},
@@ -7,7 +8,6 @@ use core::{
     ptr::NonNull,
     str,
 };
-use core::{time, u32};
 
 #[cfg(feature = "alloc")]
 use alloc::{


### PR DESCRIPTION
# Description

This removes the use of legacy `core::u32` constant which is depreceated and reported by Clippy.
