### PR TITLE
sys: Fix `halt!` and `crash!` message handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - `flipperzero_sys::furi::FuriBox` for low-level heap allocations
+- `flipperzero_sys::halt!` macro
 
 ### Changed
 
+- Fixed passing of crash message `__furi_crash_implementation`
+- Allow no argument calls to `flipperzero_sys::crash!` and `flipperzero_sys::halt!` macros
 - `flipperzero_sys::furi::UnsafeRecord::open` now takes a `&'static CStr`
 
 ### Removed


### PR DESCRIPTION
Due to the way we called `__furi_crash_implementation` the value of the `r12` register would often get clobbered, corrupting the message.

This is fixed by directly jumping to the crash handler from inline assembly.

Only messages stored on flash memory can be shown at reboot, so strings stored in RAM (including string constants in external apps) will be replaced by a generic "check serial logs" message.

This also allows calling `halt!` and `crash!` in their no-argument form.