### PR TITLE
Fix missing `ufmt` in log macro scopes

### DIFF
--- a/crates/flipperzero/src/furi/log/mod.rs
+++ b/crates/flipperzero/src/furi/log/mod.rs
@@ -24,6 +24,9 @@ pub use metadata::{Level, LevelFilter};
 #[macro_export]
 macro_rules! log {
     (target: $target:expr, $lvl:expr, $msg:expr $(, $arg:expr)*) => ({
+        // The `uwrite!` macro expects `ufmt` in scope
+        use $crate::__macro_support::ufmt;
+
         if $lvl <= $crate::furi::log::LevelFilter::current() {
             const TARGET: *const ::core::primitive::i8 =
                 match ::core::ffi::CStr::from_bytes_with_nul(


### PR DESCRIPTION
This would produce a "use of undeclared crate or module `ufmt`" error when compiling modules that didn't include `ufmt` on their own.