### PR TITLE
Make `UnsafeRecord::open` take a `&'static CStr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `flipperzero_sys::furi::UnsafeRecord::open` now takes a `&'static CStr`
+
 ### Removed
 
 ## [0.13.0]

--- a/crates/flipperzero/examples/example_images.rs
+++ b/crates/flipperzero/examples/example_images.rs
@@ -77,7 +77,7 @@ fn main(_args: Option<&CStr>) -> i32 {
         );
 
         // Register view port in GUI
-        let gui = UnsafeRecord::open(c"gui".as_ptr());
+        let gui = UnsafeRecord::open(c"gui");
         sys::gui_add_view_port(gui.as_ptr(), view_port, sys::GuiLayer_GuiLayerFullscreen);
 
         let mut event: MaybeUninit<sys::InputEvent> = MaybeUninit::uninit();

--- a/crates/flipperzero/examples/gui.rs
+++ b/crates/flipperzero/examples/gui.rs
@@ -43,7 +43,7 @@ fn main(_args: Option<&CStr>) -> i32 {
         sys::view_port_draw_callback_set(view_port, Some(draw_callback), ptr::null_mut());
 
         {
-            let gui = UnsafeRecord::open(c"gui".as_ptr());
+            let gui = UnsafeRecord::open(c"gui");
             sys::gui_add_view_port(gui.as_ptr(), view_port, FULLSCREEN);
 
             sleep(Duration::from_secs(1));

--- a/crates/flipperzero/examples/view_dispatcher.rs
+++ b/crates/flipperzero/examples/view_dispatcher.rs
@@ -103,7 +103,7 @@ fn main(_args: Option<&CStr>) -> i32 {
     }
 
     unsafe {
-        let gui = UnsafeRecord::open(c"gui".as_ptr());
+        let gui = UnsafeRecord::open(c"gui");
         sys::view_dispatcher_attach_to_gui(
             app.view_dispatcher.as_ptr(),
             gui.as_ptr(),

--- a/crates/flipperzero/src/dialogs/mod.rs
+++ b/crates/flipperzero/src/dialogs/mod.rs
@@ -44,7 +44,7 @@ impl DialogsApp {
     /// Obtains a handle to the Dialogs app.
     pub fn open() -> Self {
         Self {
-            data: unsafe { UnsafeRecord::open(c"dialogs".as_ptr()) },
+            data: unsafe { UnsafeRecord::open(c"dialogs") },
         }
     }
 

--- a/crates/flipperzero/src/dolphin/mod.rs
+++ b/crates/flipperzero/src/dolphin/mod.rs
@@ -16,7 +16,7 @@ impl Dolphin {
     /// Obtains a handle to the dolphin.
     pub fn open() -> Self {
         Self {
-            data: unsafe { UnsafeRecord::open(c"dolphin".as_ptr()) },
+            data: unsafe { UnsafeRecord::open(c"dolphin") },
         }
     }
 

--- a/crates/flipperzero/src/notification/mod.rs
+++ b/crates/flipperzero/src/notification/mod.rs
@@ -27,7 +27,7 @@ impl NotificationService {
     /// Obtains a handle to the Notifications service.
     pub fn open() -> Self {
         Self {
-            data: unsafe { UnsafeRecord::open(c"notification".as_ptr()) },
+            data: unsafe { UnsafeRecord::open(c"notification") },
         }
     }
 

--- a/crates/flipperzero/src/storage.rs
+++ b/crates/flipperzero/src/storage.rs
@@ -152,7 +152,7 @@ pub struct File(NonNull<sys::File>, UnsafeRecord<sys::Storage>);
 impl File {
     pub fn new() -> Self {
         unsafe {
-            let record = UnsafeRecord::open(c"storage".as_ptr());
+            let record = UnsafeRecord::open(c"storage");
             File(
                 NonNull::new_unchecked(sys::storage_file_alloc(record.as_ptr())),
                 record,

--- a/crates/test/src/lib.rs
+++ b/crates/test/src/lib.rs
@@ -160,8 +160,7 @@ pub mod __macro_support {
         tests: impl Iterator<Item = (&'static str, &'static str, TestFn)> + Clone,
         args: Args<'_>,
     ) -> Result<(), i32> {
-        let storage: UnsafeRecord<sys::Storage> =
-            unsafe { UnsafeRecord::open(c"storage".as_ptr()) };
+        let storage: UnsafeRecord<sys::Storage> = unsafe { UnsafeRecord::open(c"storage") };
         let mut output_file = OutputFile::new(&storage);
 
         #[inline]


### PR DESCRIPTION
This is safer and explicit about the static lifetime requirement.