### PR TITLE
Fix display of panic message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed passing of crash message `__furi_crash_implementation`
 - Allow no argument calls to `flipperzero_sys::crash!` and `flipperzero_sys::halt!` macros
 - `flipperzero_sys::furi::UnsafeRecord::open` now takes a `&'static CStr`
+- Fixed overread when printing panic message to console
+- Added short delay in panic handler so message can be seen on USB console before `furi_crash`
 
 ### Removed
 


### PR DESCRIPTION
When connected via USB serial, there is often not enough time for the output to be fully recieved before the USB device resets.

Add a short 500 ms delay before we call `furi_crash`.

This also fixes incorrect `printf` formatting strings with explicit length (the length is provided as the 'precision' value after the decimal rather than the 'width' value before the decimal).