### PR TITLE
address `unsafe_block_in_unsafe_fn` warnings

### DIFF
--- a/crates/flipperzero/Cargo.toml
+++ b/crates/flipperzero/Cargo.toml
@@ -70,6 +70,7 @@ alloc = []
 
 [lints.rust]
 rust_2024_compatibility = "warn"
+edition_2024_expr_fragment_specifier = "allow"
 
 [[test]]
 name = "dolphin"

--- a/crates/flipperzero/src/furi/sync.rs
+++ b/crates/flipperzero/src/furi/sync.rs
@@ -25,7 +25,7 @@ impl FuriMutex {
         if !mutex.is_null() {
             mutex
         } else {
-            self.create()
+            unsafe { self.create() }
         }
     }
 

--- a/crates/flipperzero/src/furi/thread.rs
+++ b/crates/flipperzero/src/furi/thread.rs
@@ -249,7 +249,7 @@ impl ThreadId {
     ///
     /// The thread pointer must be non-null and point to a valid `FuriThread`.
     pub unsafe fn from_furi_thread(thread: *mut sys::FuriThread) -> ThreadId {
-        ThreadId(sys::furi_thread_get_id(thread))
+        ThreadId(unsafe { sys::furi_thread_get_id(thread) })
     }
 }
 

--- a/crates/rt/Cargo.toml
+++ b/crates/rt/Cargo.toml
@@ -26,3 +26,4 @@ flipperzero-sys.workspace = true
 
 [lints.rust]
 rust_2024_compatibility = "warn"
+edition_2024_expr_fragment_specifier = "allow"

--- a/crates/sys/Cargo.toml
+++ b/crates/sys/Cargo.toml
@@ -26,3 +26,4 @@ ufmt.workspace = true
 
 [lints.rust]
 rust_2024_compatibility = "warn"
+edition_2024_expr_fragment_specifier = "allow"

--- a/crates/sys/src/furi.rs
+++ b/crates/sys/src/furi.rs
@@ -186,7 +186,7 @@ impl<T> UnsafeRecord<T> {
     pub unsafe fn open(name: &'static CStr) -> Self {
         Self {
             name,
-            data: crate::furi_record_open(name.as_ptr()) as *mut T,
+            data: unsafe { crate::furi_record_open(name.as_ptr()) } as *mut T,
         }
     }
 
@@ -244,7 +244,7 @@ impl<T> FuriBox<T> {
     /// The caller is responsible for ensuring the pointer is non-null, was allocated using `aligned_malloc`
     /// with the correct alignment for `T` and that the memory represents a valid `T`.
     pub unsafe fn from_raw(raw: *mut T) -> Self {
-        FuriBox(NonNull::new_unchecked(raw))
+        FuriBox(unsafe { NonNull::new_unchecked(raw) })
     }
 
     /// Returns a raw pointer to the Box’s contents.

--- a/crates/sys/src/inlines/furi_hal_gpio.rs
+++ b/crates/sys/src/inlines/furi_hal_gpio.rs
@@ -16,10 +16,11 @@ pub const GPIO_NUMBER: usize = 16;
 /// `gpio` must be non-null, and the memory it points to must be initialized.
 #[inline]
 pub unsafe extern "C" fn furi_hal_gpio_write(gpio: *const sys::GpioPin, state: bool) {
-    let port = (*gpio).port;
-    let pin = (*gpio).pin;
+    let gpio = unsafe { *gpio };
+    let port = gpio.port;
+    let pin = gpio.pin;
 
-    furi_hal_gpio_write_port_pin(port, pin, state)
+    unsafe { furi_hal_gpio_write_port_pin(port, pin, state) }
 }
 
 /// GPIO write pin.
@@ -34,10 +35,12 @@ pub unsafe extern "C" fn furi_hal_gpio_write_port_pin(
     state: bool,
 ) {
     // writing to BSSR is an atomic operation
-    core::ptr::write_volatile(
-        &mut (*port).BSRR,
-        (pin as u32) << if state { 0 } else { GPIO_NUMBER },
-    );
+    unsafe {
+        core::ptr::write_volatile(
+            &mut (*port).BSRR,
+            (pin as u32) << if state { 0 } else { GPIO_NUMBER },
+        );
+    }
 }
 
 /// GPIO read pin.
@@ -47,10 +50,11 @@ pub unsafe extern "C" fn furi_hal_gpio_write_port_pin(
 /// `gpio` must be non-null, and the memory it points to must be initialized.
 #[inline]
 pub unsafe extern "C" fn furi_hal_gpio_read(gpio: *const sys::GpioPin) -> bool {
-    let port = (*gpio).port;
-    let pin = (*gpio).pin;
+    let gpio = unsafe { *gpio };
+    let port = gpio.port;
+    let pin = gpio.pin;
 
-    furi_hal_gpio_read_port_pin(port, pin)
+    unsafe { furi_hal_gpio_read_port_pin(port, pin) }
 }
 
 /// GPIO read pin.
@@ -63,5 +67,7 @@ pub unsafe extern "C" fn furi_hal_gpio_read_port_pin(
     port: *mut sys::GPIO_TypeDef,
     pin: u16,
 ) -> bool {
-    core::ptr::read_volatile(&(*port).IDR) & pin as u32 != 0x00
+    let port = unsafe { *port };
+    let input_data_register_value = unsafe { core::ptr::read_volatile(&port.IDR) };
+    input_data_register_value & pin as u32 != 0x00
 }

--- a/tools/src/bin/generate-bindings.rs
+++ b/tools/src/bin/generate-bindings.rs
@@ -313,6 +313,7 @@ fn main() {
         .prepend_enum_name(false)
         .ctypes_prefix("core::ffi")
         .allowlist_var("API_VERSION")
+        .wrap_unsafe_ops(true)
         .header_contents("header.h", &bindings_header);
 
     for function in &symbols.functions {


### PR DESCRIPTION
- **Address `unsafe_block_in_unsafe_fn` in generated bindings**
- **Suppress warning about `expr` change in 2024 edition**
- **Address `unsafe_block_in_unsafe_fn` in safe wrappers**
