### PR TITLE
Rename `Duration`/`Instant` to `FuriDuration`/`FuriInstant`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- `flipperzero::furi::time::Duration` has been renamed to `FuriDuration`
+- `flipperzero::furi::time::Instant` has been renamed to `FuriInstant`
+
 ### Removed
 
 ## [0.14.0]

--- a/crates/flipperzero/examples/i2c-ds3231.rs
+++ b/crates/flipperzero/examples/i2c-ds3231.rs
@@ -14,7 +14,7 @@ extern crate flipperzero_alloc;
 
 use core::ffi::CStr;
 
-use flipperzero::{error, furi::time::Duration, gpio::i2c, println};
+use flipperzero::{error, furi::time::FuriDuration, gpio::i2c, println};
 use flipperzero_rt::{entry, manifest};
 use ufmt::derive::uDebug;
 
@@ -66,7 +66,7 @@ impl RtcTime {
 fn main(_args: Option<&CStr>) -> i32 {
     let mut bus = i2c::Bus::EXTERNAL.acquire();
     let rtc = i2c::DeviceAddress::new(0x68);
-    let timeout = Duration::from_millis(50);
+    let timeout = FuriDuration::from_millis(50);
 
     if bus.is_device_ready(rtc, timeout) {
         let mut data = [0; 7];

--- a/crates/flipperzero/examples/stream_buffer.rs
+++ b/crates/flipperzero/examples/stream_buffer.rs
@@ -17,7 +17,7 @@ use flipperzero::{furi, println};
 use flipperzero_rt::{entry, manifest};
 
 use core::time::Duration as CoreDuration;
-use furi::time::Duration as FuriDuration;
+use furi::time::FuriDuration;
 
 // Define the FAP Manifest for this application
 manifest!(name = "Stream buffer example");

--- a/crates/flipperzero/src/furi/stream_buffer.rs
+++ b/crates/flipperzero/src/furi/stream_buffer.rs
@@ -104,8 +104,8 @@ impl StreamBuffer {
     /// The function copies the bytes into the buffer, returning the number of bytes successfully
     /// sent.
     /// It blocks if not enough space is available until the data is sent or the timeout expires.
-    /// Passing [`Duration::ZERO`](furi::time::Duration::ZERO) immediately returns with as many
-    /// bytes as can fit, while [`Duration::WAIT_FOREVER`](furi::time::Duration::WAIT_FOREVER) waits
+    /// Passing [`FuriDuration::ZERO`](furi::time::FuriDuration::ZERO) immediately returns with as many
+    /// bytes as can fit, while [`FuriDuration::WAIT_FOREVER`](furi::time::FuriDuration::WAIT_FOREVER) waits
     /// indefinitely.
     ///
     /// # Safety
@@ -122,7 +122,7 @@ impl StreamBuffer {
     /// # Interrupt Routines
     ///
     /// The `timeout` is ignored when called from an interrupt routine.
-    pub unsafe fn send(&self, data: &[u8], timeout: furi::time::Duration) -> usize {
+    pub unsafe fn send(&self, data: &[u8], timeout: furi::time::FuriDuration) -> usize {
         let self_ptr = self.0.as_ptr();
         let data_ptr = data.as_ptr().cast();
         let data_len = data.len();
@@ -136,8 +136,8 @@ impl StreamBuffer {
     /// received.
     /// The function blocks until the [trigger level](Self::set_trigger_level) is reached, the
     /// buffer is filled, or the timeout expires.
-    /// Passing [`Duration::ZERO`](furi::time::Duration::ZERO) returns immediately with as many
-    /// bytes as available, while [`Duration::WAIT_FOREVER`](furi::time::Duration::WAIT_FOREVER)
+    /// Passing [`FuriDuration::ZERO`](furi::time::FuriDuration::ZERO) returns immediately with as many
+    /// bytes as available, while [`FuriDuration::WAIT_FOREVER`](furi::time::FuriDuration::WAIT_FOREVER)
     /// waits indefinitely.
     ///
     /// # Safety
@@ -154,7 +154,7 @@ impl StreamBuffer {
     /// # Interrupt Routines
     ///
     /// The `timeout` is ignored when called from an interrupt routine.
-    pub unsafe fn receive(&self, data: &mut [u8], timeout: furi::time::Duration) -> usize {
+    pub unsafe fn receive(&self, data: &mut [u8], timeout: furi::time::FuriDuration) -> usize {
         let self_ptr = self.0.as_ptr();
         let data_ptr: *mut c_void = data.as_mut_ptr().cast();
         let data_len = data.len();
@@ -324,7 +324,7 @@ mod stream {
         /// If the underlying stream buffer does not have enough free space, it sends only the bytes
         /// that fit and returns immediately.
         pub fn send(&self, data: &[u8]) -> usize {
-            unsafe { self.buffer_ref.send(data, furi::time::Duration::ZERO) }
+            unsafe { self.buffer_ref.send(data, furi::time::FuriDuration::ZERO) }
         }
 
         /// Sends bytes in a blocking manner.
@@ -337,7 +337,7 @@ mod stream {
         pub fn send_blocking(&self, data: &[u8]) -> usize {
             unsafe {
                 self.buffer_ref
-                    .send(data, furi::time::Duration::WAIT_FOREVER)
+                    .send(data, furi::time::FuriDuration::WAIT_FOREVER)
             }
         }
 
@@ -350,7 +350,7 @@ mod stream {
         /// # Interrupt Routines
         ///
         /// In an interrupt routine, this method behaves like [`send`](Self::send).
-        pub fn send_with_timeout(&self, data: &[u8], timeout: furi::time::Duration) -> usize {
+        pub fn send_with_timeout(&self, data: &[u8], timeout: furi::time::FuriDuration) -> usize {
             unsafe { self.buffer_ref.send(data, timeout) }
         }
     }
@@ -434,7 +434,10 @@ mod stream {
         /// It will either receive all available bytes or fill the buffer, whichever happens first.
         /// Returns the number of bytes successfully received.
         pub fn recv(&self, data: &mut [u8]) -> usize {
-            unsafe { self.buffer_ref.receive(data, furi::time::Duration::ZERO) }
+            unsafe {
+                self.buffer_ref
+                    .receive(data, furi::time::FuriDuration::ZERO)
+            }
         }
 
         /// Receive bytes, blocking if necessary.
@@ -451,7 +454,7 @@ mod stream {
         pub fn recv_blocking(&self, data: &mut [u8]) -> usize {
             unsafe {
                 self.buffer_ref
-                    .receive(data, furi::time::Duration::WAIT_FOREVER)
+                    .receive(data, furi::time::FuriDuration::WAIT_FOREVER)
             }
         }
 
@@ -464,7 +467,11 @@ mod stream {
         /// # Interrupt Routines
         ///
         /// In an interrupt routine, this method behaves like [`recv`](Self::recv).
-        pub fn recv_with_timeout(&self, data: &mut [u8], timeout: furi::time::Duration) -> usize {
+        pub fn recv_with_timeout(
+            &self,
+            data: &mut [u8],
+            timeout: furi::time::FuriDuration,
+        ) -> usize {
             unsafe { self.buffer_ref.receive(data, timeout) }
         }
     }

--- a/crates/flipperzero/src/furi/sync.rs
+++ b/crates/flipperzero/src/furi/sync.rs
@@ -7,7 +7,7 @@ use flipperzero_sys as sys;
 use lock_api::{GuardNoSend, RawMutex, RawMutexTimed};
 use sys::furi::Status;
 
-use super::time::{Duration, Instant};
+use super::time::{FuriDuration, FuriInstant};
 
 const MUTEX_TYPE: sys::FuriMutexType = sys::FuriMutexTypeNormal;
 
@@ -88,15 +88,15 @@ unsafe impl RawMutex for FuriMutex {
 }
 
 unsafe impl RawMutexTimed for FuriMutex {
-    type Duration = Duration;
-    type Instant = Instant;
+    type Duration = FuriDuration;
+    type Instant = FuriInstant;
 
     fn try_lock_for(&self, timeout: Self::Duration) -> bool {
         self.try_acquire(timeout.0)
     }
 
     fn try_lock_until(&self, timeout: Self::Instant) -> bool {
-        let now = Instant::now();
+        let now = FuriInstant::now();
         self.try_lock_for(timeout - now)
     }
 }

--- a/crates/flipperzero/src/furi/thread.rs
+++ b/crates/flipperzero/src/furi/thread.rs
@@ -19,7 +19,7 @@ use alloc::{
 
 use flipperzero_sys::{self as sys, FuriFlagNoClear, FuriFlagWaitAll, FuriFlagWaitAny, HasFlag};
 
-use crate::furi::time::Duration;
+use crate::furi::time::FuriDuration;
 
 #[cfg(feature = "alloc")]
 const MIN_STACK_SIZE: usize = 1024;
@@ -226,7 +226,7 @@ pub fn sleep(duration: core::time::Duration) {
 /// The maximum supported duration is `2^32` ticks (system timer dependent).
 ///
 /// See [`sleep`] to sleep based on arbitary duration.
-pub fn sleep_ticks(duration: Duration) {
+pub fn sleep_ticks(duration: FuriDuration) {
     unsafe {
         sys::furi_delay_tick(duration.as_ticks());
     }
@@ -296,7 +296,7 @@ pub fn get_flags() -> Result<u32, sys::furi::Status> {
 pub fn wait_any_flags(
     flags: u32,
     clear: bool,
-    timeout: Duration,
+    timeout: FuriDuration,
 ) -> Result<u32, sys::furi::Status> {
     let options = FuriFlagWaitAny.0 | (if clear { 0 } else { FuriFlagNoClear.0 });
     let result = unsafe { sys::furi_thread_flags_wait(flags, options, timeout.0) };
@@ -314,7 +314,7 @@ pub fn wait_any_flags(
 pub fn wait_all_flags(
     flags: u32,
     clear: bool,
-    timeout: Duration,
+    timeout: FuriDuration,
 ) -> Result<u32, sys::furi::Status> {
     let options = FuriFlagWaitAll.0 | (if clear { 0 } else { FuriFlagNoClear.0 });
     let result = unsafe { sys::furi_thread_flags_wait(flags, options, timeout.0) };


### PR DESCRIPTION
This is to prevent confusion between the two similar but not interchangeable types.