### PR TITLE
Fix additional 2024 Edition warnings

### DIFF
--- a/crates/alloc/src/lib.rs
+++ b/crates/alloc/src/lib.rs
@@ -5,7 +5,6 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 
 use core::alloc::{GlobalAlloc, Layout};
-use core::ffi::c_void;
 
 use flipperzero_sys as sys;
 
@@ -14,18 +13,18 @@ pub struct FuriAlloc;
 unsafe impl GlobalAlloc for FuriAlloc {
     #[inline]
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        sys::aligned_malloc(layout.size(), layout.align()) as *mut u8
+        unsafe { sys::aligned_malloc(layout.size(), layout.align()).cast() }
     }
 
     #[inline]
     unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
-        sys::aligned_free(ptr as *mut c_void);
+        unsafe { sys::aligned_free(ptr.cast()) }
     }
 
     #[inline]
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
         // https://github.com/flipperdevices/flipperzero-firmware/issues/1747#issuecomment-1253636552
-        self.alloc(layout)
+        unsafe { self.alloc(layout) }
     }
 }
 

--- a/crates/flipperzero/examples/view_dispatcher.rs
+++ b/crates/flipperzero/examples/view_dispatcher.rs
@@ -56,24 +56,32 @@ impl Drop for App {
 pub unsafe extern "C" fn text_input_callback(context: *mut c_void) {
     let app = context as *mut App;
     let mut message = FuriString::from("Hello ");
-    message.push_c_str(CStr::from_ptr((*app).name.as_ptr()));
-    sys::widget_add_string_element(
-        (*app).widget.as_ptr(),
-        128 / 2,
-        64 / 2,
-        sys::AlignCenter,
-        sys::AlignCenter,
-        sys::FontPrimary,
-        message.as_c_ptr(),
-    );
-    sys::view_dispatcher_switch_to_view((*app).view_dispatcher.as_ptr(), AppView::Widget as u32);
+    unsafe {
+        message.push_c_str(CStr::from_ptr((*app).name.as_ptr()));
+        sys::widget_add_string_element(
+            (*app).widget.as_ptr(),
+            128 / 2,
+            64 / 2,
+            sys::AlignCenter,
+            sys::AlignCenter,
+            sys::FontPrimary,
+            message.as_c_ptr(),
+        );
+        sys::view_dispatcher_switch_to_view(
+            (*app).view_dispatcher.as_ptr(),
+            AppView::Widget as u32,
+        );
+    }
 }
 
 pub unsafe extern "C" fn navigation_event_callback(context: *mut c_void) -> bool {
     let view_dispatcher = context as *mut sys::ViewDispatcher;
-    sys::view_dispatcher_stop(view_dispatcher);
-    sys::view_dispatcher_remove_view(view_dispatcher, AppView::Widget as u32);
-    sys::view_dispatcher_remove_view(view_dispatcher, AppView::TextInput as u32);
+    unsafe {
+        sys::view_dispatcher_stop(view_dispatcher);
+        sys::view_dispatcher_remove_view(view_dispatcher, AppView::Widget as u32);
+        sys::view_dispatcher_remove_view(view_dispatcher, AppView::TextInput as u32);
+    }
+
     true
 }
 

--- a/crates/flipperzero/src/furi/string/iter.rs
+++ b/crates/flipperzero/src/furi/string/iter.rs
@@ -10,7 +10,8 @@ pub unsafe fn next_code_point<'a, I: Iterator<Item = &'a u8>>(bytes: &mut I) -> 
     let mut state = sys::FuriStringUTF8StateStarting;
     let mut unicode = 0u32;
     loop {
-        sys::furi_string_utf8_decode(*bytes.next()? as c_char, &mut state, &mut unicode);
+        unsafe { sys::furi_string_utf8_decode(*bytes.next()? as c_char, &mut state, &mut unicode) };
+
         match state {
             sys::FuriStringUTF8StateStarting => break Some(unicode),
             sys::FuriStringUTF8StateError => break Some(0xfffd), // �

--- a/crates/rt/src/lib.rs
+++ b/crates/rt/src/lib.rs
@@ -17,13 +17,13 @@ mod thread;
 /// # Safety
 ///
 /// This should never be called manually.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn _start(args: *mut u8) -> i32 {
-    extern "Rust" {
+    unsafe extern "Rust" {
         fn main(args: *mut u8) -> i32;
     }
 
-    main(args)
+    unsafe { main(args) }
 }
 
 /// Defines the entry point.

--- a/crates/rt/src/manifest.rs
+++ b/crates/rt/src/manifest.rs
@@ -25,7 +25,7 @@ const DEFAULT_STACK_SIZE: u16 = 2048; // 2 KiB
 #[macro_export]
 macro_rules! manifest {
     ($($field:ident = $value:expr),* $(,)?) => {
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         #[link_section = ".fapmeta"]
         static FAP_MANIFEST: $crate::manifest::ApplicationManifestV1 = $crate::manifest::ApplicationManifestV1 {
             $( $field: $crate::_manifest_field!($field = $value), )*


### PR DESCRIPTION
Fix up several new warnings that appeared after enabling 2024 Edition lints.

The main cases here are:
- You need `unsafe` blocks around unsafe code, even in an `unsafe` function
- The `no_mangle` attribute need to be marked `unsafe`
- Prefer using `cast()` over `as *mut ...`