### PR TITLE
Fix CI build failure caused by apt database

### DIFF
--- a/.github/workflows/_build_and_test.yml
+++ b/.github/workflows/_build_and_test.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - run: rustup component add llvm-tools
-    - run: sudo apt install libudev-dev
+    - run: sudo apt update && sudo apt install libudev-dev
     - name: Build
       run: cargo build --release --verbose
     - name: Build examples

--- a/.github/workflows/_lints.yml
+++ b/.github/workflows/_lints.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install build dependencies
-        run: sudo apt install libudev-dev
+        run: sudo apt update && sudo apt install libudev-dev
       - name: Run Clippy
         uses: auguwu/clippy-action@94a9ff2f6920180b89e5c03d121d0af04a9d3e03 # 1.4.0
         with:
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install build dependencies
-        run: sudo apt install libudev-dev
+        run: sudo apt update && sudo apt install libudev-dev
       - uses: dtolnay/rust-toolchain@beta
         id: toolchain
         with:
@@ -64,7 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install build dependencies
-        run: sudo apt install libudev-dev
+        run: sudo apt update && sudo apt install libudev-dev
       # Use nightly Rust (as docs.rs does), because some of our dependencies enable the
       # `doc_cfg` feature when the `docsrs` config option is set.
       - uses: dtolnay/rust-toolchain@nightly


### PR DESCRIPTION
It looks like the `libudev-dev` package referenced in the CI scripts has been removed from the Ubuntu archive, causing CI/CD steps to fail. This can be fixed by explicitly calling `apt update` prior to installing packages.