### PR TITLE
Additional Records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `flipperzero_sys::furi::FuriBox` for low-level heap allocations
 - `flipperzero_sys::halt!` macro
+- `flipperzero::storage::Storage` handle to Storage service
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `flipperzero::furi::time::Duration` has been renamed to `FuriDuration`
 - `flipperzero::furi::time::Instant` has been renamed to `FuriInstant`
 - `flipperzero_sys::furi::UnsafeRecord` now implements `Clone` to support reference-count use
+- `flipperzero::notification::NotificationService` has been renamed `NotificationApp`
+  to match the underlying C API
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `flipperzero::furi::time::Duration` has been renamed to `FuriDuration`
 - `flipperzero::furi::time::Instant` has been renamed to `FuriInstant`
+- `flipperzero_sys::furi::UnsafeRecord` now implements `Clone` to support reference-count use
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `flipperzero::furi::hal::power::Power` handle to Power service
+
 ### Changed
 
 - `flipperzero::furi::time::Duration` has been renamed to `FuriDuration`

--- a/crates/flipperzero/examples/notification.rs
+++ b/crates/flipperzero/examples/notification.rs
@@ -14,7 +14,7 @@ use core::time::Duration;
 
 use flipperzero::{
     furi::thread::sleep,
-    notification::{feedback, led, NotificationService},
+    notification::{feedback, led, NotificationApp},
 };
 use flipperzero_rt::{entry, manifest};
 
@@ -26,7 +26,7 @@ entry!(main);
 
 // Entry point
 fn main(_args: Option<&CStr>) -> i32 {
-    let mut app = NotificationService::open();
+    let mut app = NotificationApp::open();
 
     // Set the notification LED to different colours
     for sequences in [&led::ONLY_RED, &led::ONLY_GREEN, &led::ONLY_BLUE] {

--- a/crates/flipperzero/src/furi/hal.rs
+++ b/crates/flipperzero/src/furi/hal.rs
@@ -1,0 +1,1 @@
+pub mod power;

--- a/crates/flipperzero/src/furi/hal/power.rs
+++ b/crates/flipperzero/src/furi/hal/power.rs
@@ -1,0 +1,68 @@
+//! Furi Power service.
+
+use core::ffi::CStr;
+use core::mem;
+
+use flipperzero_sys as sys;
+use flipperzero_sys::furi::UnsafeRecord;
+
+pub type PowerBootMode = sys::PowerBootMode;
+pub type PowerInfo = sys::PowerInfo;
+
+/// Handle to the Power service.
+#[derive(Clone)]
+pub struct Power {
+    record: UnsafeRecord<sys::Power>,
+}
+
+impl Power {
+    pub const NAME: &CStr = c"power";
+
+    /// Open handle to Power service.
+    pub fn open() -> Self {
+        Self {
+            record: unsafe { UnsafeRecord::open(Self::NAME) },
+        }
+    }
+
+    /// Get handle to raw [`sys::Power`] record.
+    ///
+    /// This pointer must not be `free`d or otherwise invalidated.
+    /// It must not be referenced after [`Power`] has been dropped.
+    #[inline]
+    pub fn as_ptr(&self) -> *mut sys::Power {
+        self.record.as_ptr()
+    }
+
+    /// Power off device.
+    pub fn power_off(&self) {
+        unsafe { sys::power_off(self.as_ptr()) }
+    }
+
+    /// Reboot device.
+    pub fn reboot(&self, mode: PowerBootMode) {
+        unsafe { sys::power_reboot(self.as_ptr(), mode) }
+    }
+
+    /// Get power info.
+    pub fn get_info(&self) -> PowerInfo {
+        unsafe {
+            let mut power_info = mem::zeroed();
+            sys::power_get_info(self.as_ptr(), &raw mut power_info);
+
+            power_info
+        }
+    }
+
+    /// Check battery health.
+    pub fn is_battery_healthy(&self) -> bool {
+        unsafe { sys::power_is_battery_healthy(self.as_ptr()) }
+    }
+
+    /// Enable or disable battery low level notification message.
+    pub fn enable_low_battery_level_notification(&self, enable: bool) {
+        unsafe {
+            sys::power_enable_low_battery_level_notification(self.as_ptr(), enable);
+        }
+    }
+}

--- a/crates/flipperzero/src/furi/mod.rs
+++ b/crates/flipperzero/src/furi/mod.rs
@@ -1,5 +1,6 @@
 //! Furi API.
 
+pub mod hal;
 pub mod io;
 pub mod kernel;
 pub mod log;


### PR DESCRIPTION
This PR adds `Clone` support to `UnsafeRecord` so that it can be used for reference-counting patterns and adds `Clone` for the existing Record handles.

Additionally it adds handles for `Power` and `Storage` services.